### PR TITLE
add no-std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,30 @@ jobs:
         run: just powerset nextest run
       - name: Doctests
         run: just powerset test --doc
+        
+  build-no-std:
+    name: Build on no-std
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        # 1.81 is the MSRV
+        rust-version: ["1.81", "stable"]
+      fail-fast: false
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust-version }}
+      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
+      - uses: taiki-e/install-action@cross
+      - name: Check
+        run: cross check --target thumbv7em-none-eabi --no-default-features -p iddqd
 
   miri:
-    name: Run tests on miri
+    name: Run tests with miri
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(doc_cfg)"] }
 debug-ignore = "1.0.5"
 derive-where = "1.2.7"
 hashbrown = "0.15.2"
-iddqd = { path = "crates/iddqd" }
+iddqd = { path = "crates/iddqd", default-features = false }
 iddqd-test-utils = { path = "crates/iddqd-test-utils" }
 proptest = "1.6.0"
-rustc-hash = "2.1.1"
+rustc-hash = { version = "2.1.1", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 test-strategy = "0.4.1"

--- a/crates/iddqd-test-utils/Cargo.toml
+++ b/crates/iddqd-test-utils/Cargo.toml
@@ -15,4 +15,5 @@ serde_json = { workspace = true, optional = true }
 test-strategy.workspace = true
 
 [features]
+std = ["iddqd/std"]
 serde = ["dep:serde", "dep:serde_json", "iddqd/serde"]

--- a/crates/iddqd-test-utils/src/test_item.rs
+++ b/crates/iddqd-test-utils/src/test_item.rs
@@ -1,11 +1,13 @@
 use iddqd::{
-    BiHashItem, BiHashMap, IdHashItem, IdHashMap, IdOrdItem, IdOrdMap,
-    TriHashItem, TriHashMap, bi_hash_map, bi_upcast,
+    BiHashItem, BiHashMap, IdHashItem, IdHashMap, TriHashItem, TriHashMap,
+    bi_hash_map, bi_upcast,
     errors::DuplicateItem,
-    id_hash_map, id_ord_map, id_upcast,
-    internal::{ValidateChaos, ValidateCompact, ValidationError},
+    id_hash_map, id_upcast,
+    internal::{ValidateCompact, ValidationError},
     tri_hash_map, tri_upcast,
 };
+#[cfg(feature = "std")]
+use iddqd::{IdOrdItem, IdOrdMap, id_ord_map};
 use proptest::{prelude::*, sample::SizeRange};
 use std::cell::Cell;
 use test_strategy::Arbitrary;
@@ -277,6 +279,7 @@ impl IdHashItem for TestItem {
     id_upcast!();
 }
 
+#[cfg(feature = "std")]
 impl IdOrdItem for TestItem {
     // A bit weird to return a reference to a u8, but this makes sure
     // reference-based keys work properly.
@@ -439,6 +442,7 @@ impl TestItemMap for IdHashMap<TestItem> {
     }
 }
 
+#[cfg(feature = "std")]
 impl TestItemMap for IdOrdMap<TestItem> {
     type RefMut<'a> = id_ord_map::RefMut<'a, TestItem>;
     type Iter<'a> = id_ord_map::Iter<'a, TestItem>;
@@ -457,7 +461,7 @@ impl TestItemMap for IdOrdMap<TestItem> {
         &self,
         compactness: ValidateCompact,
     ) -> Result<(), ValidationError> {
-        self.validate(compactness, ValidateChaos::No)
+        self.validate(compactness, iddqd::internal::ValidateChaos::No)
     }
 
     fn insert_unique(
@@ -537,6 +541,7 @@ impl<'a> IntoRef<'a> for id_hash_map::RefMut<'a, TestItem> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> IntoRef<'a> for id_ord_map::RefMut<'a, TestItem> {
     fn into_ref(self) -> &'a TestItem {
         self.into_ref()

--- a/crates/iddqd/Cargo.toml
+++ b/crates/iddqd/Cargo.toml
@@ -27,6 +27,8 @@ proptest.workspace = true
 test-strategy.workspace = true
 
 [features]
+default = ["std"]
+std = ["iddqd-test-utils/std", "rustc-hash/std"]
 serde = ["dep:serde", "iddqd-test-utils/serde"]
 
 [package.metadata.cargo-sync-rdme.badge.badges]
@@ -34,3 +36,7 @@ license = true
 crates-io = true
 docs-rs = true
 rust-version = true
+
+[[example]]
+name = "id-complex"
+required-features = ["std"]

--- a/crates/iddqd/README.md
+++ b/crates/iddqd/README.md
@@ -36,7 +36,7 @@ issues encountered using Rust’s default map types in practice at Oxide.
 * Keys may be borrowed from values, which allows for more flexible
   implementations. (They don’t have to be borrowed, but they can be.)
 * There’s no `insert` method; insertion must be through either
-  `insert_override` or `insert_unique`. You must pick an insertion
+  `insert_overwrite` or `insert_unique`. You must pick an insertion
   behavior.
 * The serde implementations reject duplicate keys.
 
@@ -152,14 +152,26 @@ assert_eq!(
 );
 ````
 
+## No-std compatibility
+
+Most of this crate is no-std compatible, though [`alloc`](https://doc.rust-lang.org/nightly/alloc/index.html) is required.
+
+The [`IdOrdMap`](https://docs.rs/iddqd/0.1.0/iddqd/id_ord_map/imp/struct.IdOrdMap.html) type is not currently no-std compatible due to its use of a
+thread-local. This thread-local is just a way to work around a limitation in
+std’s `BTreeMap` API, though. Either a custom B-Tree implementation, or a
+platform-specific notion of thread locals, would suffice to make
+[`IdOrdMap`](https://docs.rs/iddqd/0.1.0/iddqd/id_ord_map/imp/struct.IdOrdMap.html) no-std compatible.
+
 ## Optional features
 
 * `serde`: Enables serde support for all ID map types. *Not enabled by default.*
+* `std`: Enables std support. *Enabled by default.*
 
 ## Related work
 
 * [`bimap`](https://docs.rs/bimap) provides a bijective map, but does not
-  have a way to associate arbitrary values. However, it supports
+  have a way to associate arbitrary values with each pair of keys. However, it
+  does support an ordered map type without the need for std.
 
 ## Minimum supported Rust version (MSRV)
 

--- a/crates/iddqd/src/bi_hash_map/entry.rs
+++ b/crates/iddqd/src/bi_hash_map/entry.rs
@@ -1,5 +1,6 @@
 use super::{BiHashItem, BiHashMap, RefMut, entry_indexes::EntryIndexes};
 use crate::support::{borrow::DormantMutRef, map_hash::MapHash};
+use alloc::vec::Vec;
 use debug_ignore::DebugIgnore;
 use derive_where::derive_where;
 

--- a/crates/iddqd/src/bi_hash_map/imp.rs
+++ b/crates/iddqd/src/bi_hash_map/imp.rs
@@ -14,9 +14,10 @@ use crate::{
         map_hash::MapHash,
     },
 };
+use alloc::{collections::BTreeSet, vec::Vec};
+use core::{borrow::Borrow, fmt, hash::Hash};
 use derive_where::derive_where;
 use hashbrown::hash_table;
-use std::{borrow::Borrow, collections::BTreeSet, fmt, hash::Hash};
 
 /// A 1:1 (bijective) map for two keys and a value.
 ///
@@ -88,7 +89,7 @@ impl<T: BiHashItem> BiHashMap<T> {
         compactness: ValidateCompact,
     ) -> Result<(), ValidationError>
     where
-        T: std::fmt::Debug,
+        T: core::fmt::Debug,
     {
         self.items.validate(compactness)?;
         self.tables.validate(self.len(), compactness)?;

--- a/crates/iddqd/src/bi_hash_map/iter.rs
+++ b/crates/iddqd/src/bi_hash_map/iter.rs
@@ -1,7 +1,7 @@
 use super::{RefMut, tables::BiHashMapTables};
 use crate::{BiHashItem, support::item_set::ItemSet};
+use core::iter::FusedIterator;
 use hashbrown::hash_map;
-use std::iter::FusedIterator;
 
 /// An iterator over the elements of a [`BiHashMap`] by shared reference.
 ///

--- a/crates/iddqd/src/bi_hash_map/ref_mut.rs
+++ b/crates/iddqd/src/bi_hash_map/ref_mut.rs
@@ -1,5 +1,5 @@
 use crate::{BiHashItem, support::map_hash::MapHash};
-use std::{
+use core::{
     fmt,
     ops::{Deref, DerefMut},
 };

--- a/crates/iddqd/src/bi_hash_map/serde_impls.rs
+++ b/crates/iddqd/src/bi_hash_map/serde_impls.rs
@@ -1,6 +1,7 @@
 use crate::{BiHashItem, BiHashMap};
+use alloc::vec::Vec;
+use core::fmt;
 use serde::{Deserialize, Serialize, Serializer};
-use std::fmt;
 
 /// A `BiHashMap` serializes to the list of items. Items are serialized in
 /// arbitrary order.

--- a/crates/iddqd/src/bi_hash_map/trait_defs.rs
+++ b/crates/iddqd/src/bi_hash_map/trait_defs.rs
@@ -1,6 +1,7 @@
 //! Trait definitions for `BiHashMap`.
 
-use std::{hash::Hash, rc::Rc, sync::Arc};
+use alloc::{boxed::Box, rc::Rc, sync::Arc};
+use core::hash::Hash;
 
 /// An item in a [`BiHashMap`].
 ///

--- a/crates/iddqd/src/errors.rs
+++ b/crates/iddqd/src/errors.rs
@@ -2,7 +2,8 @@
 //!
 //! These types are shared across all map implementations in this crate.
 
-use std::fmt;
+use alloc::vec::Vec;
+use core::fmt;
 
 /// An item conflicts with existing items.
 #[derive(Debug)]
@@ -60,4 +61,4 @@ impl<T: fmt::Debug, D: fmt::Debug> fmt::Display for DuplicateItem<T, D> {
     }
 }
 
-impl<T: fmt::Debug, D: fmt::Debug> std::error::Error for DuplicateItem<T, D> {}
+impl<T: fmt::Debug, D: fmt::Debug> core::error::Error for DuplicateItem<T, D> {}

--- a/crates/iddqd/src/id_hash_map/imp.rs
+++ b/crates/iddqd/src/id_hash_map/imp.rs
@@ -7,9 +7,10 @@ use crate::{
     internal::{ValidateCompact, ValidationError},
     support::{borrow::DormantMutRef, item_set::ItemSet, map_hash::MapHash},
 };
+use alloc::collections::BTreeSet;
+use core::{borrow::Borrow, fmt, hash::Hash};
 use derive_where::derive_where;
 use hashbrown::hash_table;
-use std::{borrow::Borrow, collections::BTreeSet, fmt, hash::Hash};
 
 /// A hash map where the key is part of the value.
 #[derive_where(Default)]
@@ -75,7 +76,7 @@ impl<T: IdHashItem> IdHashMap<T> {
         compactness: ValidateCompact,
     ) -> Result<(), ValidationError>
     where
-        T: std::fmt::Debug,
+        T: core::fmt::Debug,
     {
         self.items.validate(compactness)?;
         self.tables.validate(self.len(), compactness)?;

--- a/crates/iddqd/src/id_hash_map/iter.rs
+++ b/crates/iddqd/src/id_hash_map/iter.rs
@@ -1,7 +1,7 @@
 use super::{RefMut, tables::IdHashMapTables};
 use crate::{IdHashItem, support::item_set::ItemSet};
+use core::iter::FusedIterator;
 use hashbrown::hash_map;
-use std::iter::FusedIterator;
 
 /// An iterator over the elements of a [`IdHashMap`] by shared reference.
 ///

--- a/crates/iddqd/src/id_hash_map/ref_mut.rs
+++ b/crates/iddqd/src/id_hash_map/ref_mut.rs
@@ -1,5 +1,5 @@
 use crate::{IdHashItem, support::map_hash::MapHash};
-use std::{
+use core::{
     fmt,
     ops::{Deref, DerefMut},
 };

--- a/crates/iddqd/src/id_hash_map/serde_impls.rs
+++ b/crates/iddqd/src/id_hash_map/serde_impls.rs
@@ -1,6 +1,7 @@
 use crate::{IdHashItem, IdHashMap};
+use alloc::vec::Vec;
+use core::fmt;
 use serde::{Deserialize, Serialize, Serializer};
-use std::fmt;
 
 /// A `TriHashMap` serializes to the list of items. Items are serialized in
 /// arbitrary order.

--- a/crates/iddqd/src/id_hash_map/trait_defs.rs
+++ b/crates/iddqd/src/id_hash_map/trait_defs.rs
@@ -1,4 +1,4 @@
-use std::hash::Hash;
+use core::hash::Hash;
 
 /// An element stored in an [`IdHashMap`].
 ///

--- a/crates/iddqd/src/id_ord_map/entry.rs
+++ b/crates/iddqd/src/id_ord_map/entry.rs
@@ -1,8 +1,8 @@
 use super::{IdOrdItem, IdOrdMap, RefMut};
 use crate::support::borrow::DormantMutRef;
+use core::hash::Hash;
 use debug_ignore::DebugIgnore;
 use derive_where::derive_where;
-use std::hash::Hash;
 
 /// An implementation of the Entry API for [`IdOrdMap`].
 #[derive_where(Debug)]

--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -7,8 +7,9 @@ use crate::{
     internal::{ValidateChaos, ValidateCompact, ValidationError},
     support::{borrow::DormantMutRef, item_set::ItemSet},
 };
+use alloc::collections::BTreeSet;
+use core::{borrow::Borrow, fmt, hash::Hash};
 use derive_where::derive_where;
-use std::{borrow::Borrow, collections::BTreeSet, fmt, hash::Hash};
 
 /// An ordered map where the keys are part of the values, based on a B-Tree.
 ///

--- a/crates/iddqd/src/id_ord_map/iter.rs
+++ b/crates/iddqd/src/id_ord_map/iter.rs
@@ -1,6 +1,6 @@
 use super::{IdOrdItem, RefMut, tables::IdOrdMapTables};
 use crate::support::{btree_table, item_set::ItemSet};
-use std::{hash::Hash, iter::FusedIterator};
+use core::{hash::Hash, iter::FusedIterator};
 
 /// An iterator over the elements of an [`IdOrdMap`] by shared reference.
 ///
@@ -110,7 +110,7 @@ where
         //
         // [1]:
         //     https://doc.rust-lang.org/std/ptr/index.html#pointer-to-reference-conversion
-        let item = unsafe { std::mem::transmute::<&mut T, &'a mut T>(item) };
+        let item = unsafe { core::mem::transmute::<&mut T, &'a mut T>(item) };
         Some(RefMut::new(hash, item))
     }
 }

--- a/crates/iddqd/src/id_ord_map/ref_mut.rs
+++ b/crates/iddqd/src/id_ord_map/ref_mut.rs
@@ -1,6 +1,6 @@
 use super::IdOrdItem;
 use crate::support::map_hash::MapHash;
-use std::{
+use core::{
     fmt,
     hash::Hash,
     ops::{Deref, DerefMut},

--- a/crates/iddqd/src/id_ord_map/serde_impls.rs
+++ b/crates/iddqd/src/id_ord_map/serde_impls.rs
@@ -1,8 +1,9 @@
 use super::{IdOrdItem, IdOrdMap};
+use alloc::vec::Vec;
+use core::fmt;
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer, ser::SerializeSeq,
 };
-use std::fmt;
 
 /// An `IdOrdMap` serializes to the list of items. Items are serialized in
 /// order of their keys.

--- a/crates/iddqd/src/id_ord_map/tables.rs
+++ b/crates/iddqd/src/id_ord_map/tables.rs
@@ -3,7 +3,7 @@ use crate::{
     internal::{ValidateCompact, ValidationError},
     support::{btree_table::MapBTreeTable, map_hash::MapHash},
 };
-use std::hash::Hash;
+use core::hash::Hash;
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct IdOrdMapTables {

--- a/crates/iddqd/src/id_ord_map/trait_defs.rs
+++ b/crates/iddqd/src/id_ord_map/trait_defs.rs
@@ -1,6 +1,6 @@
 //! Trait definitions for `IdOrdMap`.
 
-use std::{rc::Rc, sync::Arc};
+use alloc::{boxed::Box, rc::Rc, sync::Arc};
 
 /// An element stored in an [`IdOrdMap`].
 ///

--- a/crates/iddqd/src/internal.rs
+++ b/crates/iddqd/src/internal.rs
@@ -1,4 +1,5 @@
-use std::fmt;
+use alloc::string::String;
+use core::fmt;
 
 /// For validation, indicate whether we expect integer tables to be compact
 /// (have all values in the range 0..table.len()).
@@ -42,8 +43,8 @@ impl fmt::Display for ValidationError {
     }
 }
 
-impl std::error::Error for ValidationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ValidationError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             ValidationError::Table { error, .. } => Some(error),
             ValidationError::General(_) => None,
@@ -66,4 +67,4 @@ impl fmt::Display for TableValidationError {
     }
 }
 
-impl std::error::Error for TableValidationError {}
+impl core::error::Error for TableValidationError {}

--- a/crates/iddqd/src/lib.rs
+++ b/crates/iddqd/src/lib.rs
@@ -26,7 +26,7 @@
 //! * Keys may be borrowed from values, which allows for more flexible
 //!   implementations. (They don't have to be borrowed, but they can be.)
 //! * There's no `insert` method; insertion must be through either
-//!   `insert_override` or `insert_unique`. You must pick an insertion
+//!   `insert_overwrite` or `insert_unique`. You must pick an insertion
 //!   behavior.
 //! * The serde implementations reject duplicate keys.
 //!
@@ -47,6 +47,7 @@
 //! An example for [`IdOrdMap`]:
 //!
 //! ```
+//! # #[cfg(feature = "std")] {
 //! use iddqd::{IdOrdMap, IdOrdItem, id_upcast};
 //!
 //! #[derive(Debug)]
@@ -82,6 +83,7 @@
 //! for user in &users {
 //!     println!("User {}: {}", user.name, user.age);
 //! }
+//! # }
 //! ```
 //!
 //! An example for [`IdHashMap`], showing complex borrowed keys.
@@ -142,26 +144,46 @@
 //! );
 //! ```
 //!
+//! # No-std compatibility
+//!
+//! Most of this crate is no-std compatible, though [`alloc`] is required.
+//!
+//! The [`IdOrdMap`] type is not currently no-std compatible due to its use of a
+//! thread-local. This thread-local is just a way to work around a limitation in
+//! std's `BTreeMap` API, though. Either a custom B-Tree implementation, or a
+//! platform-specific notion of thread locals, would suffice to make
+//! [`IdOrdMap`] no-std compatible.
+//!
 //! # Optional features
 //!
 //! - `serde`: Enables serde support for all ID map types. *Not enabled by default.*
+//! - `std`: Enables std support. *Enabled by default.*
 //!
 //! # Related work
 //!
 //! - [`bimap`](https://docs.rs/bimap) provides a bijective map, but does not
-//!   have a way to associate arbitrary values. However, it supports
+//!   have a way to associate arbitrary values with each pair of keys. However, it
+//!   does support an ordered map type without the need for std.
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
 //! This crate's MSRV is **Rust 1.81**. In general we aim for 6 months of Rust
 //! compatibility.
 
+#![no_std]
 #![cfg_attr(doc_cfg, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
+
+#[cfg_attr(not(feature = "std"), macro_use)] // for `format!`
+extern crate alloc;
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
 
 pub mod bi_hash_map;
 pub mod errors;
 pub mod id_hash_map;
+#[cfg(feature = "std")]
 pub mod id_ord_map;
 #[doc(hidden)]
 pub mod internal;
@@ -171,5 +193,6 @@ pub mod tri_hash_map;
 
 pub use bi_hash_map::{imp::BiHashMap, trait_defs::BiHashItem};
 pub use id_hash_map::{imp::IdHashMap, trait_defs::IdHashItem};
+#[cfg(feature = "std")]
 pub use id_ord_map::{imp::IdOrdMap, trait_defs::IdOrdItem};
 pub use tri_hash_map::{imp::TriHashMap, trait_defs::TriHashItem};

--- a/crates/iddqd/src/support/btree_table.rs
+++ b/crates/iddqd/src/support/btree_table.rs
@@ -4,14 +4,17 @@
 //! integers (that are indexes corresponding to items), but use an external
 //! comparator.
 
-use super::map_hash::MapHash;
+use super::map_hash::{HashState, MapHash};
 use crate::internal::{TableValidationError, ValidateCompact};
-use std::{
+use alloc::{
+    collections::{BTreeSet, btree_set},
+    vec::Vec,
+};
+use core::{
     borrow::Borrow,
     cell::Cell,
     cmp::Ordering,
-    collections::{BTreeSet, btree_set},
-    hash::{BuildHasher, Hash, RandomState},
+    hash::{BuildHasher, Hash},
     marker::PhantomData,
 };
 
@@ -38,7 +41,7 @@ thread_local! {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct MapBTreeTable {
     items: BTreeSet<Index>,
-    hash_state: RandomState,
+    hash_state: HashState,
 }
 
 impl MapBTreeTable {
@@ -180,10 +183,7 @@ impl MapBTreeTable {
     }
 
     pub(crate) fn compute_hash<K: Hash>(&self, key: K) -> MapHash {
-        MapHash {
-            state: self.hash_state.clone(),
-            hash: self.hash_state.hash_one(key),
-        }
+        MapHash { state: self.hash_state, hash: self.hash_state.hash_one(key) }
     }
 }
 

--- a/crates/iddqd/src/support/fmt_utils.rs
+++ b/crates/iddqd/src/support/fmt_utils.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 /// Debug impl for a static string without quotes.
 pub(crate) struct StrDisplayAsDebug(pub(crate) &'static str);

--- a/crates/iddqd/src/support/item_set.rs
+++ b/crates/iddqd/src/support/item_set.rs
@@ -1,8 +1,8 @@
 use crate::internal::{ValidateCompact, ValidationError};
+use core::ops::{Index, IndexMut};
 use derive_where::derive_where;
 use hashbrown::{HashMap, hash_map};
 use rustc_hash::FxBuildHasher;
-use std::ops::{Index, IndexMut};
 
 /// A map of items stored by integer index.
 #[derive(Clone, Debug)]
@@ -111,6 +111,8 @@ impl<T> ItemSet<T> {
         self.items.get_many_mut(indexes)
     }
 
+    // This is only used by IdOrdMap.
+    #[cfg_attr(not(feature = "std"), expect(dead_code))]
     #[inline]
     pub(crate) fn next_index(&self) -> usize {
         self.next_index

--- a/crates/iddqd/src/support/map_hash.rs
+++ b/crates/iddqd/src/support/map_hash.rs
@@ -1,9 +1,12 @@
-use std::hash::{BuildHasher, Hash, RandomState};
+use core::hash::{BuildHasher, Hash};
+use hashbrown::DefaultHashBuilder;
+
+pub(crate) type HashState = DefaultHashBuilder;
 
 /// Packages up a state and a hash for later validation.
 #[derive(Clone, Debug)]
 pub(crate) struct MapHash {
-    pub(super) state: RandomState,
+    pub(super) state: HashState,
     pub(super) hash: u64,
 }
 

--- a/crates/iddqd/src/support/mod.rs
+++ b/crates/iddqd/src/support/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod borrow;
+#[cfg(feature = "std")]
 pub(crate) mod btree_table;
 pub(crate) mod fmt_utils;
 pub(crate) mod hash_table;

--- a/crates/iddqd/src/tri_hash_map/imp.rs
+++ b/crates/iddqd/src/tri_hash_map/imp.rs
@@ -7,9 +7,10 @@ use crate::{
         fmt_utils::StrDisplayAsDebug, item_set::ItemSet, map_hash::MapHash,
     },
 };
+use alloc::{collections::BTreeSet, vec::Vec};
+use core::{borrow::Borrow, fmt, hash::Hash};
 use derive_where::derive_where;
 use hashbrown::hash_table::{Entry, VacantEntry};
-use std::{borrow::Borrow, collections::BTreeSet, fmt, hash::Hash};
 
 /// A 1:1:1 (trijective) map for three keys and a value.
 ///
@@ -81,7 +82,7 @@ impl<T: TriHashItem> TriHashMap<T> {
         compactness: crate::internal::ValidateCompact,
     ) -> Result<(), ValidationError>
     where
-        T: std::fmt::Debug,
+        T: core::fmt::Debug,
     {
         self.items.validate(compactness)?;
         self.tables.validate(self.len(), compactness)?;

--- a/crates/iddqd/src/tri_hash_map/iter.rs
+++ b/crates/iddqd/src/tri_hash_map/iter.rs
@@ -1,7 +1,7 @@
 use super::{RefMut, tables::TriHashMapTables};
 use crate::{TriHashItem, support::item_set::ItemSet};
+use core::iter::FusedIterator;
 use hashbrown::hash_map;
-use std::iter::FusedIterator;
 
 /// An iterator over the elements of a [`TriHashMap`] by shared reference.
 ///

--- a/crates/iddqd/src/tri_hash_map/ref_mut.rs
+++ b/crates/iddqd/src/tri_hash_map/ref_mut.rs
@@ -1,5 +1,5 @@
 use crate::{TriHashItem, support::map_hash::MapHash};
-use std::{
+use core::{
     fmt,
     ops::{Deref, DerefMut},
 };

--- a/crates/iddqd/src/tri_hash_map/serde_impls.rs
+++ b/crates/iddqd/src/tri_hash_map/serde_impls.rs
@@ -1,6 +1,7 @@
 use crate::{TriHashItem, TriHashMap};
+use alloc::vec::Vec;
+use core::fmt;
 use serde::{Deserialize, Serialize, Serializer};
-use std::fmt;
 
 /// A `TriHashMap` serializes to the list of items. Items are serialized in
 /// arbitrary order.

--- a/crates/iddqd/src/tri_hash_map/trait_defs.rs
+++ b/crates/iddqd/src/tri_hash_map/trait_defs.rs
@@ -1,6 +1,7 @@
 //! Trait definitions for `TriHashMap`.
 
-use std::{hash::Hash, rc::Rc, sync::Arc};
+use alloc::{boxed::Box, rc::Rc, sync::Arc};
+use core::hash::Hash;
 
 /// An item in a [`TriHashMap`].
 ///

--- a/crates/iddqd/tests/integration/main.rs
+++ b/crates/iddqd/tests/integration/main.rs
@@ -1,4 +1,5 @@
 mod bi_hash_map;
 mod id_hash_map;
+#[cfg(feature = "std")]
 mod id_ord_map;
 mod tri_hash_map;


### PR DESCRIPTION
Most of this crate is no-std compatible. IdOrdMap is the only bit that isn't due to its use of thread-locals.