### PR TITLE
update daft impls for BiHashMap and TriHashMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.0] - 2025-05-21
+
+### Added
+
+- `Extend` implementations.
+
+### Changed
+
+- Daft implementations for `BiHashMap` and `TriHashMap` changed to also allow diffing by individual keys.
+
 ## [0.1.2] - 2025-05-21
 
 ### Added
@@ -21,6 +31,7 @@
 
 Initial release.
 
+[0.2.0]: https://github.com/oxidecomputer/iddqd/releases/iddqd-0.2.0
 [0.1.2]: https://github.com/oxidecomputer/iddqd/releases/iddqd-0.1.2
 [0.1.1]: https://github.com/oxidecomputer/iddqd/releases/iddqd-0.1.1
 [0.1.0]: https://github.com/oxidecomputer/iddqd/releases/iddqd-0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "hashbrown",
  "iddqd-test-utils",
  "proptest",
+ "ref-cast",
  "rustc-hash",
  "serde",
  "test-strategy",
@@ -308,6 +309,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ hashbrown = "0.15.2"
 iddqd = { path = "crates/iddqd", default-features = false }
 iddqd-test-utils = { path = "crates/iddqd-test-utils" }
 proptest = "1.6.0"
+ref-cast = "1.0.24"
 rustc-hash = { version = "2.1.1", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/crates/iddqd/Cargo.toml
+++ b/crates/iddqd/Cargo.toml
@@ -23,6 +23,7 @@ daft = { workspace = true, optional = true }
 debug-ignore.workspace = true
 derive-where.workspace = true
 hashbrown.workspace = true
+ref-cast = { workspace = true, optional = true }
 rustc-hash.workspace = true
 serde = { workspace = true, optional = true }
 
@@ -32,7 +33,7 @@ proptest.workspace = true
 test-strategy.workspace = true
 
 [features]
-daft = ["dep:daft"]
+daft = ["dep:daft", "dep:ref-cast"]
 default = ["std"]
 std = ["iddqd-test-utils/std", "rustc-hash/std"]
 serde = ["dep:serde", "iddqd-test-utils/serde"]

--- a/crates/iddqd/src/bi_hash_map/daft_impls.rs
+++ b/crates/iddqd/src/bi_hash_map/daft_impls.rs
@@ -1,29 +1,91 @@
 //! `Diffable` implementation.
 
 use super::{BiHashItem, BiHashMap};
-use crate::support::daft_utils::IdLeaf;
-use core::{borrow::Borrow, hash::Hash};
+use crate::{IdHashItem, id_hash_map, support::daft_utils::IdLeaf};
+use core::{borrow::Borrow, fmt, hash::Hash};
 use daft::Diffable;
+use derive_where::derive_where;
+use ref_cast::RefCast;
 
 impl<T: BiHashItem> Diffable for BiHashMap<T> {
     type Diff<'a>
-        = Diff<'a, T>
+        = MapLeaf<'a, T>
     where
         T: 'a;
 
     fn diff<'daft>(&'daft self, other: &'daft Self) -> Self::Diff<'daft> {
+        MapLeaf { before: self, after: other }
+    }
+}
+
+/// A leaf diff of two [`BiHashMap`]s.
+///
+/// This diff is lazy and has not been evaluated yet. To evaluate the diff,
+/// call:
+///
+/// * [`Self::by_key1`] to get a diff indexed by `key1`.
+/// * [`Self::by_key2`] to get a diff indexed by `key2`.
+/// * [`Self::by_unique`] to get a diff indexed by `key1` and `key2`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive_where(
+    Debug;
+    T: fmt::Debug,
+    for<'k> T::K1<'k>: fmt::Debug,
+    for<'k> T::K2<'k>: fmt::Debug
+)]
+pub struct MapLeaf<'daft, T: BiHashItem> {
+    /// The before map.
+    pub before: &'daft BiHashMap<T>,
+
+    /// The after map.
+    pub after: &'daft BiHashMap<T>,
+}
+
+impl<'daft, T: BiHashItem> MapLeaf<'daft, T> {
+    /// Returns a diff of two [`BiHashMap`]s, indexed by `key1`.
+    ///
+    /// Note that the return type is a [`id_hash_map::Diff`].
+    pub fn by_key1(self) -> id_hash_map::Diff<'daft, ByK1<T>> {
+        impl_diff_ref_cast!(
+            self,
+            id_hash_map::Diff::<'daft, ByK1<T>>,
+            key1,
+            get1,
+            contains_key1,
+            ByK1<T>
+        )
+    }
+
+    /// Returns a diff of two [`BiHashMap`]s, indexed by `key2`.
+    ///
+    /// Note that the return type is a [`id_hash_map::Diff`].
+    pub fn by_key2(self) -> id_hash_map::Diff<'daft, ByK2<T>> {
+        impl_diff_ref_cast!(
+            self,
+            id_hash_map::Diff::<'daft, ByK2<T>>,
+            key2,
+            get2,
+            contains_key2,
+            ByK2<T>
+        )
+    }
+
+    /// Returns a diff of two [`BiHashMap`]s, indexed by `key1` and `key2`.
+    ///
+    /// The return type is a [`Diff`].
+    pub fn by_unique(self) -> Diff<'daft, T> {
         let mut diff = Diff::new();
-        for item in self {
-            if let Some(other_item) =
-                other.get_unique(&item.key1(), &item.key2())
+        for item in self.before {
+            if let Some(after_item) =
+                self.after.get_unique(&item.key1(), &item.key2())
             {
-                diff.common.insert_overwrite(IdLeaf::new(item, other_item));
+                diff.common.insert_overwrite(IdLeaf::new(item, after_item));
             } else {
                 diff.removed.insert_overwrite(item);
             }
         }
-        for item in other {
-            if !self.contains_key_unique(&item.key1(), &item.key2()) {
+        for item in self.after {
+            if !self.before.contains_key_unique(&item.key1(), &item.key2()) {
                 diff.added.insert_overwrite(item);
             }
         }
@@ -31,7 +93,7 @@ impl<T: BiHashItem> Diffable for BiHashMap<T> {
     }
 }
 
-/// A diff of two [`BiHashMap`]s.
+/// A diff of two [`BiHashMap`]s, indexed by both `key1` and `key2`.
 pub struct Diff<'daft, T: ?Sized + BiHashItem> {
     /// Entries common to both maps.
     ///
@@ -179,6 +241,7 @@ impl<'daft, T: ?Sized + BiHashItem + Eq> Diff<'daft, T> {
 // Note: not deriving Default here because we don't want to require
 // T to be Default.
 impl<'daft, T: BiHashItem> Default for Diff<'daft, T> {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
@@ -221,6 +284,82 @@ impl<T: BiHashItem> BiHashItem for IdLeaf<T> {
     fn upcast_key2<'short, 'long: 'short>(
         long: Self::K2<'long>,
     ) -> Self::K2<'short> {
+        T::upcast_key2(long)
+    }
+}
+
+/// Maps a [`BiHashItem`] to an [`IdHashItem`], indexed by `key1`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, RefCast)]
+#[repr(transparent)]
+pub struct ByK1<T>(pub T);
+
+impl<T> ByK1<T> {
+    /// Converts a `&T` to a `&ByK1<T>`.
+    #[inline]
+    pub fn ref_cast(item: &T) -> &Self {
+        RefCast::ref_cast(item)
+    }
+
+    /// Converts a `&mut T` to a `&mut ByK1<T>`.
+    #[inline]
+    pub fn ref_cast_mut(item: &mut T) -> &mut Self {
+        RefCast::ref_cast_mut(item)
+    }
+}
+
+impl<T: BiHashItem> IdHashItem for ByK1<T> {
+    type Key<'a>
+        = T::K1<'a>
+    where
+        T: 'a;
+
+    #[inline]
+    fn key(&self) -> Self::Key<'_> {
+        self.0.key1()
+    }
+
+    #[inline]
+    fn upcast_key<'short, 'long: 'short>(
+        long: Self::Key<'long>,
+    ) -> Self::Key<'short> {
+        T::upcast_key1(long)
+    }
+}
+
+/// Maps a [`BiHashItem`] to an [`IdHashItem`], indexed by `key2`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, RefCast)]
+#[repr(transparent)]
+pub struct ByK2<T>(pub T);
+
+impl<T> ByK2<T> {
+    /// Converts a `&T` to a `&ByK1<T>`.
+    #[inline]
+    pub fn ref_cast(item: &T) -> &Self {
+        RefCast::ref_cast(item)
+    }
+
+    /// Converts a `&mut T` to a `&mut ByK1<T>`.
+    #[inline]
+    pub fn ref_cast_mut(item: &mut T) -> &mut Self {
+        RefCast::ref_cast_mut(item)
+    }
+}
+
+impl<T: BiHashItem> IdHashItem for ByK2<T> {
+    type Key<'a>
+        = T::K2<'a>
+    where
+        T: 'a;
+
+    #[inline]
+    fn key(&self) -> Self::Key<'_> {
+        self.0.key2()
+    }
+
+    #[inline]
+    fn upcast_key<'short, 'long: 'short>(
+        long: Self::Key<'long>,
+    ) -> Self::Key<'short> {
         T::upcast_key2(long)
     }
 }

--- a/crates/iddqd/src/bi_hash_map/mod.rs
+++ b/crates/iddqd/src/bi_hash_map/mod.rs
@@ -15,7 +15,7 @@ mod tables;
 pub(crate) mod trait_defs;
 
 #[cfg(feature = "daft")]
-pub use daft_impls::Diff;
+pub use daft_impls::{ByK1, ByK2, Diff, MapLeaf};
 pub use entry::{
     Entry, OccupiedEntry, OccupiedEntryMut, OccupiedEntryRef, VacantEntry,
 };

--- a/crates/iddqd/src/lib.rs
+++ b/crates/iddqd/src/lib.rs
@@ -194,6 +194,10 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
+// This must go first so macros can be used in the rest of the crate.
+#[macro_use]
+mod macros;
+
 pub mod bi_hash_map;
 pub mod errors;
 pub mod id_hash_map;
@@ -201,7 +205,6 @@ pub mod id_hash_map;
 pub mod id_ord_map;
 #[doc(hidden)]
 pub mod internal;
-mod macros;
 mod support;
 pub mod tri_hash_map;
 

--- a/crates/iddqd/src/tri_hash_map/mod.rs
+++ b/crates/iddqd/src/tri_hash_map/mod.rs
@@ -13,7 +13,7 @@ mod tables;
 pub(crate) mod trait_defs;
 
 #[cfg(feature = "daft")]
-pub use daft_impls::Diff;
+pub use daft_impls::{ByK1, ByK2, ByK3, Diff, MapLeaf};
 pub use imp::TriHashMap;
 pub use iter::{IntoIter, Iter, IterMut};
 pub use ref_mut::RefMut;


### PR DESCRIPTION
Making this lazy, then asking folks to decide which way to perform diffs, makes a lot of sense. These are generally tricky, so I wouldn't be surprised if they are sparingly used.