### PR TITLE
try running with opt-level 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ rustc-hash = { version = "2.1.1", default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 test-strategy = "0.4.1"
+
+[profile.dev]
+# Builds with opt-level 1 speed up test runs by around 20x.
+opt-level = 1

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -138,19 +138,9 @@ impl Operation {
     }
 }
 
-// Miri is quite slow, so run fewer operations.
-#[cfg(miri)]
-const OP_LEN: usize = 64;
-#[cfg(miri)]
-const PERMUTATION_LEN: usize = 16;
-#[cfg(not(miri))]
-const OP_LEN: usize = 1024;
-#[cfg(not(miri))]
-const PERMUTATION_LEN: usize = 256;
-
 #[proptest(cases = 16)]
 fn proptest_ops(
-    #[strategy(prop::collection::vec(any::<Operation>(), 0..OP_LEN))] ops: Vec<
+    #[strategy(prop::collection::vec(any::<Operation>(), 0..1024))] ops: Vec<
         Operation,
     >,
 ) {
@@ -217,7 +207,7 @@ fn proptest_ops(
 
 #[proptest(cases = 64)]
 fn proptest_permutation_eq(
-    #[strategy(test_item_permutation_strategy::<IdHashMap<TestItem>>(0..PERMUTATION_LEN))]
+    #[strategy(test_item_permutation_strategy::<IdHashMap<TestItem>>(0..256))]
     items: (Vec<TestItem>, Vec<TestItem>),
 ) {
     let (items1, items2) = items;

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -177,19 +177,9 @@ impl Operation {
     }
 }
 
-// Miri is quite slow, so run fewer operations.
-#[cfg(miri)]
-const OP_LEN: usize = 64;
-#[cfg(miri)]
-const PERMUTATION_LEN: usize = 16;
-#[cfg(not(miri))]
-const OP_LEN: usize = 1024;
-#[cfg(not(miri))]
-const PERMUTATION_LEN: usize = 256;
-
 #[proptest(cases = 16)]
 fn proptest_ops(
-    #[strategy(prop::collection::vec(any::<Operation>(), 0..OP_LEN))] ops: Vec<
+    #[strategy(prop::collection::vec(any::<Operation>(), 0..1024))] ops: Vec<
         Operation,
     >,
 ) {
@@ -259,7 +249,7 @@ fn proptest_ops(
 
 #[proptest(cases = 64)]
 fn proptest_permutation_eq(
-    #[strategy(test_item_permutation_strategy::<IdOrdMap<TestItem>>(0..PERMUTATION_LEN))]
+    #[strategy(test_item_permutation_strategy::<IdOrdMap<TestItem>>(0..256))]
     items: (Vec<TestItem>, Vec<TestItem>),
 ) {
     let (items1, items2) = items;


### PR DESCRIPTION
This speeds up test runs locally, and CI runs go from 5+ minutes to 3m30s.