### PR TITLE
use Equivalent, drop borrow checker limitations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "daft",
  "debug-ignore",
  "derive-where",
+ "equivalent",
  "hashbrown",
  "iddqd-test-utils",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(doc_cfg)"] }
 daft = { version = "0.1.3", default-features = false }
 debug-ignore = "1.0.5"
 derive-where = "1.2.7"
+equivalent = "1.0.2"
 hashbrown = "0.15.2"
 iddqd = { path = "crates/iddqd", default-features = false }
 iddqd-test-utils = { path = "crates/iddqd-test-utils" }

--- a/crates/iddqd/Cargo.toml
+++ b/crates/iddqd/Cargo.toml
@@ -22,6 +22,7 @@ workspace = true
 daft = { workspace = true, optional = true }
 debug-ignore.workspace = true
 derive-where.workspace = true
+equivalent.workspace = true
 hashbrown.workspace = true
 ref-cast = { workspace = true, optional = true }
 rustc-hash.workspace = true

--- a/crates/iddqd/examples/id-complex.rs
+++ b/crates/iddqd/examples/id-complex.rs
@@ -75,7 +75,7 @@ fn main() {
     // `Hash`. For example:
     {
         let mut item =
-            map.get_mut(MyKey { b: 20, c: Path::new("/"), d: &[] }).unwrap();
+            map.get_mut(&MyKey { b: 20, c: Path::new("/"), d: &[] }).unwrap();
         item.a = "changed".to_owned();
 
         // Key changes will be checked when the item is dropped.

--- a/crates/iddqd/src/support/hash_table.rs
+++ b/crates/iddqd/src/support/hash_table.rs
@@ -7,6 +7,7 @@ use core::{
     borrow::Borrow,
     hash::{BuildHasher, Hash},
 };
+use equivalent::Equivalent;
 use hashbrown::{
     DefaultHashBuilder, HashTable,
     hash_table::{AbsentEntry, Entry, OccupiedEntry},
@@ -99,11 +100,10 @@ impl MapHashTable {
     ) -> Option<usize>
     where
         F: Fn(usize) -> K,
-        K: Hash + Eq + Borrow<Q>,
-        Q: ?Sized + Hash + Eq,
+        Q: ?Sized + Hash + Equivalent<K>,
     {
         let hash = self.state.hash_one(key);
-        self.items.find(hash, |index| lookup(*index).borrow() == key).copied()
+        self.items.find(hash, |index| key.equivalent(&lookup(*index))).copied()
     }
 
     pub(crate) fn entry<K: Hash + Eq, F>(

--- a/crates/iddqd/src/tri_hash_map/imp.rs
+++ b/crates/iddqd/src/tri_hash_map/imp.rs
@@ -343,8 +343,8 @@ impl<T: TriHashItem> TriHashMap<T> {
         let (dormant_map, remove_index) = {
             let (map, dormant_map) = DormantMutRef::new(self);
             let remove_index = map.find1_index(key1)?;
-            if !key2.equivalent(&map.items[remove_index].key2())
-                && !key3.equivalent(&map.items[remove_index].key3())
+            let item = &map.items[remove_index];
+            if !key2.equivalent(&item.key2()) && !key3.equivalent(&item.key3())
             {
                 return None;
             }

--- a/crates/iddqd/tests/integration/bi_hash_map.rs
+++ b/crates/iddqd/tests/integration/bi_hash_map.rs
@@ -52,7 +52,7 @@ fn debug_impls() {
           {k1: 20, k2: 'b'}: SimpleItem { key1: 20, key2: 'b' }}",
     );
     assert_eq!(
-        format!("{:?}", map.get1_mut(1).unwrap()),
+        format!("{:?}", map.get1_mut(&1).unwrap()),
         "SimpleItem { key1: 1, key2: 'a' }"
     );
 }
@@ -115,8 +115,8 @@ fn test_insert_unique() {
     // Check that the *unique methods work.
     assert!(map.contains_key_unique(&v4.key1(), &v4.key2()));
     assert_eq!(map.get_unique(&v4.key1(), &v4.key2()), Some(&v4));
-    assert_eq!(*map.get_mut_unique(v4.key1(), v4.key2()).unwrap(), &v4);
-    assert_eq!(map.remove_unique(v4.key1(), v4.key2()), Some(v4));
+    assert_eq!(*map.get_mut_unique(&v4.key1(), &v4.key2()).unwrap(), &v4);
+    assert_eq!(map.remove_unique(&v4.key1(), &v4.key2()), Some(v4));
 }
 
 #[test]
@@ -248,14 +248,14 @@ fn proptest_ops(
                 assert_eq!(map_res, naive_res);
             }
             Operation::Remove1(key1) => {
-                let map_res = map.remove1(TestKey1::new(&key1));
+                let map_res = map.remove1(&TestKey1::new(&key1));
                 let naive_res = naive_map.remove1(key1);
 
                 assert_eq!(map_res, naive_res);
                 map.validate(compactness).expect("map should be valid");
             }
             Operation::Remove2(key2) => {
-                let map_res = map.remove2(TestKey2::new(key2));
+                let map_res = map.remove2(&TestKey2::new(key2));
                 let naive_res = naive_map.remove2(key2);
 
                 assert_eq!(map_res, naive_res);
@@ -355,7 +355,7 @@ fn test_permutation_eq_examples() {
 fn get_mut_panics_if_key1_changes() {
     let mut map = BiHashMap::<TestItem>::new();
     map.insert_unique(TestItem::new(128, 'b', "y", "x")).unwrap();
-    map.get1_mut(TestKey1::new(&128)).unwrap().key1 = 2;
+    map.get1_mut(&TestKey1::new(&128)).unwrap().key1 = 2;
 }
 
 #[test]
@@ -363,7 +363,7 @@ fn get_mut_panics_if_key1_changes() {
 fn get_mut_panics_if_key2_changes() {
     let mut map = BiHashMap::<TestItem>::new();
     map.insert_unique(TestItem::new(128, 'b', "y", "x")).unwrap();
-    map.get1_mut(TestKey1::new(&128)).unwrap().key2 = 'c';
+    map.get1_mut(&TestKey1::new(&128)).unwrap().key2 = 'c';
 }
 
 #[test]

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -43,7 +43,7 @@ fn debug_impls() {
         r#"{1: SimpleItem { key: 1 }, 10: SimpleItem { key: 10 }, 20: SimpleItem { key: 20 }}"#
     );
     assert_eq!(
-        format!("{:?}", map.get_mut(1).unwrap()),
+        format!("{:?}", map.get_mut(&1).unwrap()),
         "SimpleItem { key: 1 }"
     );
 }
@@ -189,7 +189,7 @@ fn proptest_ops(
                 assert_eq!(map_res, naive_res);
             }
             Operation::Remove(key) => {
-                let map_res = map.remove(TestKey1::new(&key));
+                let map_res = map.remove(&TestKey1::new(&key));
                 let naive_res = naive_map.remove1(key);
 
                 assert_eq!(map_res, naive_res);
@@ -298,7 +298,7 @@ fn test_permutation_eq_examples() {
 fn get_mut_panics_if_key_changes() {
     let mut map = IdHashMap::<TestItem>::new();
     map.insert_unique(TestItem::new(128, 'b', "y", "x")).unwrap();
-    map.get_mut(TestKey1::new(&128)).unwrap().key1 = 2;
+    map.get_mut(&TestKey1::new(&128)).unwrap().key1 = 2;
 }
 
 #[test]

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -63,7 +63,7 @@ fn debug_impls() {
         r#"{1: SimpleItem { key: 1 }, 10: SimpleItem { key: 10 }, 20: SimpleItem { key: 20 }}"#
     );
     assert_eq!(
-        format!("{:?}", map.get_mut(1).unwrap()),
+        format!("{:?}", map.get_mut(&1).unwrap()),
         "SimpleItem { key: 1 }"
     );
 }
@@ -230,7 +230,7 @@ fn proptest_ops(
                 assert_eq!(map_res, naive_res);
             }
             Operation::Remove(key) => {
-                let map_res = map.remove(TestKey1::new(&key));
+                let map_res = map.remove(&TestKey1::new(&key));
                 let naive_res = naive_map.remove1(key);
 
                 assert_eq!(map_res, naive_res);
@@ -346,7 +346,7 @@ fn test_permutation_eq_examples() {
 fn get_mut_panics_if_key_changes() {
     let mut map = IdOrdMap::<TestItem>::new();
     map.insert_unique(TestItem::new(128, 'b', "y", "x")).unwrap();
-    map.get_mut(TestKey1::new(&128)).unwrap().key1 = 2;
+    map.get_mut(&TestKey1::new(&128)).unwrap().key1 = 2;
 }
 
 #[test]

--- a/crates/iddqd/tests/integration/tri_hash_map.rs
+++ b/crates/iddqd/tests/integration/tri_hash_map.rs
@@ -56,7 +56,7 @@ fn debug_impls() {
           {k1: 20, k2: 'b', k3: 1}: SimpleItem { key1: 20, key2: 'b', key3: 1 }}",
     );
     assert_eq!(
-        format!("{:?}", map.get1_mut(1).unwrap()),
+        format!("{:?}", map.get1_mut(&1).unwrap()),
         "SimpleItem { key1: 1, key2: 'a', key3: 0 }"
     );
 }
@@ -157,10 +157,10 @@ fn test_insert_unique() {
     assert!(map.contains_key_unique(&v5.key1(), &v5.key2(), &v5.key3()));
     assert_eq!(map.get_unique(&v5.key1(), &v5.key2(), &v5.key3()), Some(&v5));
     assert_eq!(
-        *map.get_mut_unique(v5.key1(), v5.key2(), v5.key3()).unwrap(),
+        *map.get_mut_unique(&v5.key1(), &v5.key2(), &v5.key3()).unwrap(),
         &v5
     );
-    assert_eq!(map.remove_unique(v5.key1(), v5.key2(), v5.key3()), Some(v5));
+    assert_eq!(map.remove_unique(&v5.key1(), &v5.key2(), &v5.key3()), Some(v5));
 }
 
 // Example-based test for insert_overwrite.
@@ -280,21 +280,21 @@ fn proptest_ops(
                 assert_eq!(map_res, naive_res);
             }
             Operation::Remove1(key1) => {
-                let map_res = map.remove1(TestKey1::new(&key1));
+                let map_res = map.remove1(&TestKey1::new(&key1));
                 let naive_res = naive_map.remove1(key1);
 
                 assert_eq!(map_res, naive_res);
                 map.validate(compactness).expect("map should be valid");
             }
             Operation::Remove2(key2) => {
-                let map_res = map.remove2(TestKey2::new(key2));
+                let map_res = map.remove2(&TestKey2::new(key2));
                 let naive_res = naive_map.remove2(key2);
 
                 assert_eq!(map_res, naive_res);
                 map.validate(compactness).expect("map should be valid");
             }
             Operation::Remove3(key3) => {
-                let map_res = map.remove3(TestKey3::new(&key3));
+                let map_res = map.remove3(&TestKey3::new(&key3));
                 let naive_res = naive_map.remove3(&key3);
 
                 assert_eq!(map_res, naive_res);
@@ -408,7 +408,7 @@ fn test_permutation_eq_examples() {
 fn get_mut_panics_if_key1_changes() {
     let mut map = TriHashMap::<TestItem>::new();
     map.insert_unique(TestItem::new(128, 'b', "y", "x")).unwrap();
-    map.get1_mut(TestKey1::new(&128)).unwrap().key1 = 2;
+    map.get1_mut(&TestKey1::new(&128)).unwrap().key1 = 2;
 }
 
 #[test]
@@ -416,7 +416,7 @@ fn get_mut_panics_if_key1_changes() {
 fn get_mut_panics_if_key2_changes() {
     let mut map = TriHashMap::<TestItem>::new();
     map.insert_unique(TestItem::new(128, 'b', "y", "x")).unwrap();
-    map.get1_mut(TestKey1::new(&128)).unwrap().key2 = 'c';
+    map.get1_mut(&TestKey1::new(&128)).unwrap().key2 = 'c';
 }
 
 #[test]
@@ -424,7 +424,7 @@ fn get_mut_panics_if_key2_changes() {
 fn get_mut_panics_if_key3_changes() {
     let mut map = TriHashMap::<TestItem>::new();
     map.insert_unique(TestItem::new(128, 'b', "y", "x")).unwrap();
-    map.get1_mut(TestKey1::new(&128)).unwrap().key3 = "z".to_owned();
+    map.get1_mut(&TestKey1::new(&128)).unwrap().key3 = "z".to_owned();
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
With stacked borrows through `DormantMutRef`, we can accept borrowed forms.

`Equivalent` is also strictly more general than `Borrow`.
