### PR TITLE
Add support for tuples in Bi/TriHashMap

### DIFF
--- a/crates/iddqd/src/bi_hash_map/trait_defs.rs
+++ b/crates/iddqd/src/bi_hash_map/trait_defs.rs
@@ -82,6 +82,51 @@ pub trait BiHashItem {
     ) -> Self::K2<'short>;
 }
 
+impl<A, B> BiHashItem for (A, B)
+where
+    A: Eq + Hash,
+    B: Eq + Hash,
+{
+    type K1<'a>
+        = &'a A
+    where
+        A: 'a,
+        B: 'a;
+    type K2<'a>
+        = &'a B
+    where
+        A: 'a,
+        B: 'a;
+
+    fn key1(&self) -> Self::K1<'_> {
+        &self.0
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        &self.1
+    }
+
+    fn upcast_key1<'short, 'long: 'short>(
+        long: Self::K1<'long>,
+    ) -> Self::K1<'short>
+    where
+        A: 'long,
+        B: 'long,
+    {
+        long
+    }
+
+    fn upcast_key2<'short, 'long: 'short>(
+        long: Self::K2<'long>,
+    ) -> Self::K2<'short>
+    where
+        A: 'long,
+        B: 'long,
+    {
+        long
+    }
+}
+
 macro_rules! impl_for_ref {
     ($type:ty) => {
         impl<'b, T: 'b + ?Sized + BiHashItem> BiHashItem for $type {

--- a/crates/iddqd/src/tri_hash_map/trait_defs.rs
+++ b/crates/iddqd/src/tri_hash_map/trait_defs.rs
@@ -116,6 +116,77 @@ pub trait TriHashItem {
     ) -> Self::K3<'short>;
 }
 
+impl<A, B, C> TriHashItem for (A, B, C)
+where
+    A: Eq + Hash,
+    B: Eq + Hash,
+    C: Eq + Hash,
+{
+    type K1<'a>
+        = &'a A
+    where
+        A: 'a,
+        B: 'a,
+        C: 'a;
+    type K2<'a>
+        = &'a B
+    where
+        A: 'a,
+        B: 'a,
+        C: 'a;
+    type K3<'a>
+        = &'a C
+    where
+        A: 'a,
+        B: 'a,
+        C: 'a;
+
+    fn key1(&self) -> Self::K1<'_> {
+        &self.0
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        &self.1
+    }
+
+    fn key3(&self) -> Self::K3<'_> {
+        &self.2
+    }
+
+    fn upcast_key1<'short, 'long: 'short>(
+        long: Self::K1<'long>,
+    ) -> Self::K1<'short>
+    where
+        A: 'long,
+        B: 'long,
+        C: 'long,
+    {
+        long
+    }
+
+    fn upcast_key2<'short, 'long: 'short>(
+        long: Self::K2<'long>,
+    ) -> Self::K2<'short>
+    where
+        A: 'long,
+        B: 'long,
+        C: 'long,
+    {
+        long
+    }
+
+    fn upcast_key3<'short, 'long: 'short>(
+        long: Self::K3<'long>,
+    ) -> Self::K3<'short>
+    where
+        A: 'long,
+        B: 'long,
+        C: 'long,
+    {
+        long
+    }
+}
+
 macro_rules! impl_for_ref {
     ($type:ty) => {
         impl<'b, T: 'b + ?Sized + TriHashItem> TriHashItem for $type {


### PR DESCRIPTION
I didn't feel like making a custom pair struct for the ten lines of code I was using this map in and decided to try and implement `BiHashItem` for tuples. Somewhat surprisingly this appears to work fine. All the lifetime annotations appear to be necessary, though I would be lying if I said I fully understood why... they were all recommended by rustc.

There's an unfortunate naming clash here, where `entity_map.get1(&square).unwrap().1` means using the first element of the tuple (`get1`) to get the second element of the tuple (`.1`). Renaming `get1` and friends would solve this if that's something you would consider.