### PR TITLE
add Self: 'long bound to upcast_key impls, use in bumpalo example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(doc_cfg)"] }
 
 [workspace.dependencies]
 allocator-api2 = { version = "0.2.21", default-features = false, features = ["alloc"] }
-bumpalo = { version = "3.17.0", features = ["allocator-api2"] }
+bumpalo = { version = "3.17.0", features = ["allocator-api2", "collections"] }
 daft = { version = "0.1.3", default-features = false }
 equivalent = "1.0.2"
 foldhash = "0.1.5"

--- a/crates/iddqd/src/macros.rs
+++ b/crates/iddqd/src/macros.rs
@@ -16,7 +16,10 @@ macro_rules! id_upcast {
         #[inline]
         fn upcast_key<'short, 'long: 'short>(
             long: Self::Key<'long>,
-        ) -> Self::Key<'short> {
+        ) -> Self::Key<'short>
+        where
+            Self: 'long,
+        {
             long
         }
     };
@@ -37,14 +40,20 @@ macro_rules! bi_upcast {
         #[inline]
         fn upcast_key1<'short, 'long: 'short>(
             long: Self::K1<'long>,
-        ) -> Self::K1<'short> {
+        ) -> Self::K1<'short>
+        where
+            Self: 'long,
+        {
             long
         }
 
         #[inline]
         fn upcast_key2<'short, 'long: 'short>(
             long: Self::K2<'long>,
-        ) -> Self::K2<'short> {
+        ) -> Self::K2<'short>
+        where
+            Self: 'long,
+        {
             long
         }
     };
@@ -65,21 +74,30 @@ macro_rules! tri_upcast {
         #[inline]
         fn upcast_key1<'short, 'long: 'short>(
             long: Self::K1<'long>,
-        ) -> Self::K1<'short> {
+        ) -> Self::K1<'short>
+        where
+            Self: 'long,
+        {
             long
         }
 
         #[inline]
         fn upcast_key2<'short, 'long: 'short>(
             long: Self::K2<'long>,
-        ) -> Self::K2<'short> {
+        ) -> Self::K2<'short>
+        where
+            Self: 'long,
+        {
             long
         }
 
         #[inline]
         fn upcast_key3<'short, 'long: 'short>(
             long: Self::K3<'long>,
-        ) -> Self::K3<'short> {
+        ) -> Self::K3<'short>
+        where
+            Self: 'long,
+        {
             long
         }
     };


### PR DESCRIPTION
Since bumpalo doesn't run destructors on drop, the example would result in a memory leak. Use bumpalo-provided types to address that.

This led to me also finding out that the `_upcast` macros need a `Self: 'long` bound.
