### PR TITLE
add macros to construct map literals easily

### DIFF
--- a/crates/iddqd/src/macros.rs
+++ b/crates/iddqd/src/macros.rs
@@ -1,5 +1,303 @@
 //! Macros for this crate.
 
+/// Creates an [`IdHashMap`](crate::IdHashMap) from a list of items.
+///
+/// An optional [`BuildHasher`](core::hash::BuildHasher) that implements
+/// `Default` can be provided as the first argument, followed by a semicolon.
+///
+/// # Panics
+///
+/// Panics if the list of items has duplicate keys. For better error handling,
+/// the item is required to implement `Debug`.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "default-hasher")] {
+/// use iddqd::{IdHashItem, id_hash_map, id_upcast};
+///
+/// #[derive(Debug)]
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// impl IdHashItem for User {
+///     type Key<'a> = u32;
+///     fn key(&self) -> Self::Key<'_> {
+///         self.id
+///     }
+///     id_upcast!();
+/// }
+///
+/// let map = id_hash_map! {
+///     User { id: 1, name: "Alice".to_string() },
+///     User { id: 2, name: "Bob".to_string() },
+/// };
+/// assert_eq!(map.get(&1).unwrap().name, "Alice");
+/// assert_eq!(map.get(&2).unwrap().name, "Bob");
+///
+/// // With a custom hasher:
+/// let map = id_hash_map! {
+///     foldhash::quality::RandomState;
+///     User { id: 3, name: "Charlie".to_string() },
+///     User { id: 4, name: "Eve".to_string() },
+/// };
+/// assert_eq!(map.get(&3).unwrap().name, "Charlie");
+/// assert_eq!(map.get(&4).unwrap().name, "Eve");
+/// # }
+/// ```
+#[macro_export]
+macro_rules! id_hash_map {
+    ($($item:expr,)+) => { $crate::id_hash_map!($($item),+) };
+    ($($item:expr),*) => {
+        {
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const CAP: usize = <[()]>::len(&[$({ stringify!($item); }),*]);
+            let mut map = $crate::IdHashMap::with_capacity(CAP);
+            $(
+                map.insert_unique($item).unwrap();
+            )*
+            map
+        }
+    };
+    ($H:ty; $($item:expr,)+) => { $crate::id_hash_map!($H; $($item),+) };
+    ($H:ty; $($item:expr),*) => {
+        {
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const CAP: usize = <[()]>::len(&[$({ stringify!($item); }),*]);
+            let mut map = $crate::IdHashMap::with_capacity_and_hasher(CAP, <$H>::default());
+            $(
+                map.insert_unique($item).unwrap();
+            )*
+            map
+        }
+    };
+}
+
+/// Creates an [`IdOrdMap`](crate::IdOrdMap) from a list of items.
+///
+/// # Panics
+///
+/// Panics if the list of items has duplicate keys. For better error handling,
+/// the item is required to implement `Debug`.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "std")] {
+/// use iddqd::{IdOrdItem, id_ord_map, id_upcast};
+///
+/// #[derive(Debug)]
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// impl IdOrdItem for User {
+///     type Key<'a> = u32;
+///     fn key(&self) -> Self::Key<'_> {
+///         self.id
+///     }
+///     id_upcast!();
+/// }
+///
+/// let map = id_ord_map! {
+///     User { id: 1, name: "Alice".to_string() },
+///     User { id: 2, name: "Bob".to_string() },
+/// };
+/// assert_eq!(map.get(&1).unwrap().name, "Alice");
+/// assert_eq!(map.get(&2).unwrap().name, "Bob");
+/// # }
+/// ```
+#[cfg(feature = "std")]
+#[macro_export]
+macro_rules! id_ord_map {
+    ($($item:expr,)+) => { $crate::id_ord_map!($($item),+) };
+    ($($item:expr),*) => {
+        {
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const CAP: usize = <[()]>::len(&[$({ stringify!($item); }),*]);
+            let mut map = $crate::IdOrdMap::with_capacity(CAP);
+            $(
+                map.insert_unique($item).unwrap();
+            )*
+            map
+        }
+    };
+}
+
+/// Creates a [`BiHashMap`](crate::BiHashMap) from a list of items.
+///
+/// An optional [`BuildHasher`](core::hash::BuildHasher) that implements
+/// `Default` can be provided as the first argument, followed by a semicolon.
+///
+/// # Panics
+///
+/// Panics if the list of items has duplicate keys. For better error handling,
+/// the item is required to implement `Debug`.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "default-hasher")] {
+/// use iddqd::{BiHashItem, bi_hash_map, bi_upcast};
+///
+/// #[derive(Debug)]
+/// struct User {
+///     id: u32,
+///     name: String,
+/// }
+///
+/// impl BiHashItem for User {
+///     type K1<'a> = u32;
+///     type K2<'a> = &'a str;
+///     fn key1(&self) -> Self::K1<'_> {
+///         self.id
+///     }
+///     fn key2(&self) -> Self::K2<'_> {
+///         &self.name
+///     }
+///     bi_upcast!();
+/// }
+///
+/// let map = bi_hash_map! {
+///     User { id: 1, name: "Alice".to_string() },
+///     User { id: 2, name: "Bob".to_string() },
+/// };
+/// assert_eq!(map.get1(&1).unwrap().name, "Alice");
+/// assert_eq!(map.get2("Bob").unwrap().id, 2);
+///
+/// // With a custom hasher:
+/// let map = bi_hash_map! {
+///     foldhash::quality::RandomState;
+///     User { id: 3, name: "Charlie".to_string() },
+///     User { id: 4, name: "Eve".to_string() },
+/// };
+/// assert_eq!(map.get1(&3).unwrap().name, "Charlie");
+/// assert_eq!(map.get2("Eve").unwrap().id, 4);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! bi_hash_map {
+    ($($item:expr,)+) => { $crate::bi_hash_map!($($item),+) };
+    ($($item:expr),*) => {
+        {
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const CAP: usize = <[()]>::len(&[$({ stringify!($item); }),*]);
+            let mut map = $crate::BiHashMap::with_capacity(CAP);
+            $(
+                map.insert_unique($item).unwrap();
+            )*
+            map
+        }
+    };
+    ($H:ty; $($item:expr,)+) => { $crate::bi_hash_map!($H; $($item),+) };
+    ($H:ty; $($item:expr),*) => {
+        {
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const CAP: usize = <[()]>::len(&[$({ stringify!($item); }),*]);
+            let mut map = $crate::BiHashMap::with_capacity_and_hasher(CAP, <$H>::default());
+            $(
+                map.insert_unique($item).unwrap();
+            )*
+            map
+        }
+    };
+}
+
+/// Creates a [`TriHashMap`](crate::TriHashMap) from a list of items.
+///
+/// An optional [`BuildHasher`](core::hash::BuildHasher) that implements
+/// `Default` can be provided as the first argument, followed by a semicolon.
+///
+/// # Panics
+///
+/// Panics if the list of items has duplicate keys. For better error handling,
+/// the item is required to implement `Debug`.
+///
+/// # Examples
+///
+/// ```
+/// # #[cfg(feature = "default-hasher")] {
+/// use iddqd::{TriHashItem, tri_hash_map, tri_upcast};
+///
+/// #[derive(Debug)]
+/// struct Person {
+///     id: u32,
+///     name: String,
+///     email: String,
+/// }
+///
+/// impl TriHashItem for Person {
+///     type K1<'a> = u32;
+///     type K2<'a> = &'a str;
+///     type K3<'a> = &'a str;
+///     fn key1(&self) -> Self::K1<'_> {
+///         self.id
+///     }
+///     fn key2(&self) -> Self::K2<'_> {
+///         &self.name
+///     }
+///     fn key3(&self) -> Self::K3<'_> {
+///         &self.email
+///     }
+///     tri_upcast!();
+/// }
+///
+/// let map = tri_hash_map! {
+///     Person { id: 1, name: "Alice".to_string(), email: "alice@example.com".to_string() },
+///     Person { id: 2, name: "Bob".to_string(), email: "bob@example.com".to_string() },
+/// };
+/// assert_eq!(map.get1(&1).unwrap().name, "Alice");
+/// assert_eq!(map.get2("Bob").unwrap().id, 2);
+/// assert_eq!(map.get3("alice@example.com").unwrap().name, "Alice");
+///
+/// // With a custom hasher:
+/// let map = tri_hash_map! {
+///     foldhash::quality::RandomState;
+///     Person { id: 3, name: "Charlie".to_string(), email: "charlie@example.com".to_string() },
+///     Person { id: 4, name: "Eve".to_string(), email: "eve@example.com".to_string() },
+/// };
+/// assert_eq!(map.get1(&3).unwrap().name, "Charlie");
+/// assert_eq!(map.get2("Eve").unwrap().id, 4);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! tri_hash_map {
+    ($($item:expr,)+) => { $crate::tri_hash_map!($($item),+) };
+    ($($item:expr),*) => {
+        {
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const CAP: usize = <[()]>::len(&[$({ stringify!($item); }),*]);
+            let mut map = $crate::TriHashMap::with_capacity(CAP);
+            $(
+                map.insert_unique($item).unwrap();
+            )*
+            map
+        }
+    };
+    ($H:ty; $($item:expr,)+) => { $crate::tri_hash_map!($H; $($item),+) };
+    ($H:ty; $($item:expr),*) => {
+        {
+            // Note: `stringify!($key)` is just here to consume the repetition,
+            // but we throw away that string literal during constant evaluation.
+            const CAP: usize = <[()]>::len(&[$({ stringify!($item); }),*]);
+            let mut map = $crate::TriHashMap::with_capacity_and_hasher(CAP, <$H>::default());
+            $(
+                map.insert_unique($item).unwrap();
+            )*
+            map
+        }
+    };
+}
+
 /// Implement upcasts for [`IdOrdMap`] or [`IdHashMap`].
 ///
 /// The maps in this crate require that the key types' lifetimes are covariant.

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -1,7 +1,5 @@
 use iddqd::{
-    IdOrdItem, IdOrdMap, id_ord_map,
-    id_ord_map::{Entry, RefMut},
-    id_upcast,
+    IdOrdItem, IdOrdMap, id_ord_map, id_upcast,
     internal::{ValidateChaos, ValidateCompact},
 };
 use iddqd_test_utils::{
@@ -90,8 +88,8 @@ fn test_compact_chaos() {
         // iter_mut can potentially cause mutable UB.
         catch_panic(|| map.iter_mut().collect::<Vec<_>>());
         catch_panic(|| match map.entry(item.key()) {
-            Entry::Vacant(_) => {}
-            Entry::Occupied(mut entry) => {
+            id_ord_map::Entry::Vacant(_) => {}
+            id_ord_map::Entry::Occupied(mut entry) => {
                 // This can trigger some unsafe code.
                 {
                     let _mut1 = entry.get_mut();
@@ -139,7 +137,7 @@ fn test_insert_unique() {
 
     // Iterate over the items mutably. This ensures that miri detects UB if it
     // exists.
-    let items: Vec<RefMut<_>> = map.iter_mut().collect();
+    let items: Vec<id_ord_map::RefMut<_>> = map.iter_mut().collect();
     let e1 = &items[0];
     assert_eq!(**e1, v3);
 
@@ -354,7 +352,7 @@ fn entry_examples() {
     let mut map = IdOrdMap::<TestItem>::make_new();
     let item1 = TestItem::new(0, 'a', "x", "v");
 
-    let Entry::Vacant(entry) = map.entry(item1.key()) else {
+    let id_ord_map::Entry::Vacant(entry) = map.entry(item1.key()) else {
         panic!("expected VacantEntry")
     };
     let mut entry = entry.insert_entry(item1.clone());
@@ -366,7 +364,7 @@ fn entry_examples() {
     // Try looking up another item with the same key1.
     let item2 = TestItem::new(0, 'b', "y", "x");
 
-    let Entry::Occupied(mut entry) = map.entry(item2.key()) else {
+    let id_ord_map::Entry::Occupied(mut entry) = map.entry(item2.key()) else {
         panic!("expected OccupiedEntry");
     };
     assert_eq!(entry.insert(item2.clone()), item1);
@@ -432,7 +430,7 @@ fn or_insert_ref_panics_for_present_key() {
 
     let v2 = TestItem::new(1, 'a', "bar", "value");
     let entry = map.entry(v2.key());
-    assert!(matches!(entry, Entry::Vacant(_)));
+    assert!(matches!(entry, id_ord_map::Entry::Vacant(_)));
     // Try inserting v1, which is present in the map.
     entry.or_insert_ref(v1);
 }
@@ -446,7 +444,7 @@ fn or_insert_panics_for_present_key() {
 
     let v2 = TestItem::new(1, 'a', "bar", "value");
     let entry = map.entry(v2.key());
-    assert!(matches!(entry, Entry::Vacant(_)));
+    assert!(matches!(entry, id_ord_map::Entry::Vacant(_)));
     // Try inserting v1, which is present in the map.
     entry.or_insert(v1);
 }
@@ -460,9 +458,9 @@ fn insert_entry_panics_for_present_key() {
 
     let v2 = TestItem::new(1, 'a', "bar", "value");
     let entry = map.entry(v2.key());
-    assert!(matches!(entry, Entry::Vacant(_)));
+    assert!(matches!(entry, id_ord_map::Entry::Vacant(_)));
     // Try inserting v1, which is present in the map.
-    if let Entry::Vacant(vacant_entry) = entry {
+    if let id_ord_map::Entry::Vacant(vacant_entry) = entry {
         vacant_entry.insert_entry(v1);
     } else {
         panic!("Expected Vacant entry");
@@ -487,7 +485,7 @@ mod macro_tests {
     }
 
     #[test]
-    fn test_id_ord_map_macro() {
+    fn macro_basic() {
         let map = id_ord_map! {
             User { id: 1, name: "Alice".to_string() },
             User { id: 2, name: "Bob".to_string() },
@@ -499,21 +497,22 @@ mod macro_tests {
     }
 
     #[test]
-    fn test_id_ord_map_macro_empty() {
-        let _empty_map: IdOrdMap<User> = id_ord_map! {};
+    fn macro_empty() {
+        let empty_map: IdOrdMap<User> = id_ord_map! {};
+        assert!(empty_map.is_empty());
     }
 
     #[test]
-    fn test_id_ord_map_macro_trailing_comma() {
+    fn macro_without_trailing_comma() {
         let map = id_ord_map! {
-            User { id: 1, name: "Alice".to_string() },
+            User { id: 1, name: "Alice".to_string() }
         };
         assert_eq!(map.len(), 1);
     }
 
     #[test]
     #[should_panic(expected = "DuplicateItem")]
-    fn test_id_ord_map_macro_duplicate_key() {
+    fn macro_duplicate_key() {
         let _map = id_ord_map! {
             User { id: 1, name: "Alice".to_string() },
             User { id: 1, name: "Bob".to_string() },

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -1,5 +1,5 @@
 use iddqd::{
-    IdOrdItem, IdOrdMap,
+    IdOrdItem, IdOrdMap, id_ord_map,
     id_ord_map::{Entry, RefMut},
     id_upcast,
     internal::{ValidateChaos, ValidateCompact},
@@ -466,6 +466,58 @@ fn insert_entry_panics_for_present_key() {
         vacant_entry.insert_entry(v1);
     } else {
         panic!("Expected Vacant entry");
+    }
+}
+
+mod macro_tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct User {
+        id: u32,
+        name: String,
+    }
+
+    impl IdOrdItem for User {
+        type Key<'a> = u32;
+        fn key(&self) -> Self::Key<'_> {
+            self.id
+        }
+        id_upcast!();
+    }
+
+    #[test]
+    fn test_id_ord_map_macro() {
+        let map = id_ord_map! {
+            User { id: 1, name: "Alice".to_string() },
+            User { id: 2, name: "Bob".to_string() },
+        };
+
+        assert_eq!(map.len(), 2);
+        assert_eq!(map.get(&1).unwrap().name, "Alice");
+        assert_eq!(map.get(&2).unwrap().name, "Bob");
+    }
+
+    #[test]
+    fn test_id_ord_map_macro_empty() {
+        let _empty_map: IdOrdMap<User> = id_ord_map! {};
+    }
+
+    #[test]
+    fn test_id_ord_map_macro_trailing_comma() {
+        let map = id_ord_map! {
+            User { id: 1, name: "Alice".to_string() },
+        };
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "DuplicateItem")]
+    fn test_id_ord_map_macro_duplicate_key() {
+        let _map = id_ord_map! {
+            User { id: 1, name: "Alice".to_string() },
+            User { id: 1, name: "Bob".to_string() },
+        };
     }
 }
 

--- a/crates/iddqd/tests/integration/tri_hash_map.rs
+++ b/crates/iddqd/tests/integration/tri_hash_map.rs
@@ -1,6 +1,6 @@
 use iddqd::{
     TriHashItem, TriHashMap, internal::ValidateCompact, tri_hash_map,
-    tri_hash_map::RefMut, tri_upcast,
+    tri_upcast,
 };
 use iddqd_test_utils::{
     eq_props::{assert_eq_props, assert_ne_props},
@@ -139,7 +139,8 @@ fn test_insert_unique() {
     // Iterate over the items mutably. This ensures that miri detects UB if it
     // exists.
     {
-        let mut items: Vec<RefMut<_, HashBuilder>> = map.iter_mut().collect();
+        let mut items: Vec<tri_hash_map::RefMut<_, HashBuilder>> =
+            map.iter_mut().collect();
         items.sort_by(|a, b| a.key1().cmp(&b.key1()));
         let e1 = &items[0];
         assert_eq!(**e1, v1);
@@ -458,7 +459,7 @@ mod macro_tests {
 
     #[cfg(feature = "default-hasher")]
     #[test]
-    fn test_tri_hash_map_macro() {
+    fn macro_basic() {
         let map = tri_hash_map! {
             Person { id: 1, name: "Alice".to_string(), email: "alice@example.com".to_string() },
             Person { id: 2, name: "Bob".to_string(), email: "bob@example.com".to_string() },
@@ -471,7 +472,7 @@ mod macro_tests {
     }
 
     #[test]
-    fn test_tri_hash_map_macro_with_hasher() {
+    fn macro_with_hasher() {
         let map = tri_hash_map! {
             HashBuilder;
             Person { id: 3, name: "Charlie".to_string(), email: "charlie@example.com".to_string() },
@@ -486,15 +487,16 @@ mod macro_tests {
 
     #[cfg(feature = "default-hasher")]
     #[test]
-    fn test_tri_hash_map_macro_empty() {
-        let _empty_map: TriHashMap<Person> = tri_hash_map! {};
+    fn macro_empty() {
+        let empty_map: TriHashMap<Person> = tri_hash_map! {};
+        assert!(empty_map.is_empty());
     }
 
     #[cfg(feature = "default-hasher")]
     #[test]
-    fn test_tri_hash_map_macro_trailing_comma() {
+    fn macro_without_trailing_comma() {
         let map = tri_hash_map! {
-            Person { id: 1, name: "Alice".to_string(), email: "alice@example.com".to_string() },
+            Person { id: 1, name: "Alice".to_string(), email: "alice@example.com".to_string() }
         };
         assert_eq!(map.len(), 1);
     }
@@ -502,7 +504,7 @@ mod macro_tests {
     #[cfg(feature = "default-hasher")]
     #[test]
     #[should_panic(expected = "DuplicateItem")]
-    fn test_tri_hash_map_macro_duplicate_key1() {
+    fn macro_duplicate_key1() {
         let _map = tri_hash_map! {
             Person { id: 1, name: "Alice".to_string(), email: "alice@example.com".to_string() },
             Person { id: 1, name: "Bob".to_string(), email: "bob@example.com".to_string() },
@@ -512,7 +514,7 @@ mod macro_tests {
     #[cfg(feature = "default-hasher")]
     #[test]
     #[should_panic(expected = "DuplicateItem")]
-    fn test_tri_hash_map_macro_duplicate_key2() {
+    fn macro_duplicate_key2() {
         let _map = tri_hash_map! {
             Person { id: 1, name: "Alice".to_string(), email: "alice@example.com".to_string() },
             Person { id: 2, name: "Alice".to_string(), email: "alice2@example.com".to_string() },
@@ -522,7 +524,7 @@ mod macro_tests {
     #[cfg(feature = "default-hasher")]
     #[test]
     #[should_panic(expected = "DuplicateItem")]
-    fn test_tri_hash_map_macro_duplicate_key3() {
+    fn macro_duplicate_key3() {
         let _map = tri_hash_map! {
             Person { id: 1, name: "Alice".to_string(), email: "alice@example.com".to_string() },
             Person { id: 2, name: "Bob".to_string(), email: "alice@example.com".to_string() },


### PR DESCRIPTION
Inspired by indexmap's macros.

These macros are named the same as the corresponding modules for ease of use.