### PR TITLE
relax Debug impls to only require T::Key<'a>: Debug for a particular 'a

### DIFF
--- a/crates/iddqd-test-utils/src/borrowed_item.rs
+++ b/crates/iddqd-test-utils/src/borrowed_item.rs
@@ -1,6 +1,7 @@
+#[cfg(feature = "std")]
+use iddqd::IdOrdItem;
 use iddqd::{
-    BiHashItem, IdHashItem, IdOrdItem, TriHashItem, bi_upcast, id_upcast,
-    tri_upcast,
+    BiHashItem, IdHashItem, TriHashItem, bi_upcast, id_upcast, tri_upcast,
 };
 use std::path::Path;
 
@@ -24,6 +25,7 @@ impl<'a> IdHashItem for BorrowedItem<'a> {
     id_upcast!();
 }
 
+#[cfg(feature = "std")]
 impl<'a> IdOrdItem for BorrowedItem<'a> {
     type Key<'k>
         = &'a str

--- a/crates/iddqd-test-utils/src/borrowed_item.rs
+++ b/crates/iddqd-test-utils/src/borrowed_item.rs
@@ -1,0 +1,88 @@
+use iddqd::{
+    BiHashItem, IdHashItem, IdOrdItem, TriHashItem, bi_upcast, id_upcast,
+    tri_upcast,
+};
+use std::path::Path;
+
+#[derive(Clone, Debug)]
+pub struct BorrowedItem<'a> {
+    pub key1: &'a str,
+    pub key2: &'a [u8],
+    pub key3: &'a Path,
+}
+
+impl<'a> IdHashItem for BorrowedItem<'a> {
+    type Key<'k>
+        = &'a str
+    where
+        Self: 'k;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.key1
+    }
+
+    id_upcast!();
+}
+
+impl<'a> IdOrdItem for BorrowedItem<'a> {
+    type Key<'k>
+        = &'a str
+    where
+        Self: 'k;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.key1
+    }
+
+    id_upcast!();
+}
+
+impl<'a> BiHashItem for BorrowedItem<'a> {
+    type K1<'k>
+        = &'a str
+    where
+        Self: 'k;
+    type K2<'k>
+        = &'a [u8]
+    where
+        Self: 'k;
+
+    fn key1(&self) -> Self::K1<'_> {
+        self.key1
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        self.key2
+    }
+
+    bi_upcast!();
+}
+
+impl<'a> TriHashItem for BorrowedItem<'a> {
+    type K1<'k>
+        = &'a str
+    where
+        Self: 'k;
+    type K2<'k>
+        = &'a [u8]
+    where
+        Self: 'k;
+    type K3<'k>
+        = &'a Path
+    where
+        Self: 'k;
+
+    fn key1(&self) -> Self::K1<'_> {
+        self.key1
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        self.key2
+    }
+
+    fn key3(&self) -> Self::K3<'_> {
+        self.key3
+    }
+
+    tri_upcast!();
+}

--- a/crates/iddqd-test-utils/src/lib.rs
+++ b/crates/iddqd-test-utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod borrowed_item;
 pub mod eq_props;
 pub mod naive_map;
 #[cfg(feature = "serde")]

--- a/crates/iddqd/src/bi_hash_map/daft_impls.rs
+++ b/crates/iddqd/src/bi_hash_map/daft_impls.rs
@@ -116,11 +116,12 @@ pub struct MapLeaf<
     pub after: &'daft BiHashMap<T, S, A>,
 }
 
-impl<'daft, T: BiHashItem + fmt::Debug, S, A: Allocator> fmt::Debug
+impl<'a, 'daft, T: BiHashItem + fmt::Debug, S, A: Allocator> fmt::Debug
     for MapLeaf<'daft, T, S, A>
 where
-    for<'k> T::K1<'k>: fmt::Debug,
-    for<'k> T::K2<'k>: fmt::Debug,
+    T::K1<'a>: fmt::Debug,
+    T::K2<'a>: fmt::Debug,
+    T: 'a,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MapLeaf")

--- a/crates/iddqd/src/tri_hash_map/daft_impls.rs
+++ b/crates/iddqd/src/tri_hash_map/daft_impls.rs
@@ -158,12 +158,13 @@ pub struct MapLeaf<
     pub after: &'daft TriHashMap<T, S, A>,
 }
 
-impl<'daft, T: TriHashItem + fmt::Debug, S, A: Allocator> fmt::Debug
+impl<'a, 'daft, T: TriHashItem + fmt::Debug, S, A: Allocator> fmt::Debug
     for MapLeaf<'daft, T, S, A>
 where
-    for<'k> T::K1<'k>: fmt::Debug,
-    for<'k> T::K2<'k>: fmt::Debug,
-    for<'k> T::K3<'k>: fmt::Debug,
+    T::K1<'a>: fmt::Debug,
+    T::K2<'a>: fmt::Debug,
+    T::K3<'a>: fmt::Debug,
+    T: 'a,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MapLeaf")

--- a/crates/iddqd/src/tri_hash_map/imp.rs
+++ b/crates/iddqd/src/tri_hash_map/imp.rs
@@ -2260,49 +2260,56 @@ impl<T: TriHashItem, S: Clone + BuildHasher, A: Allocator> TriHashMap<T, S, A> {
     }
 }
 
-impl<T, S, A: Allocator> fmt::Debug for TriHashMap<T, S, A>
+impl<'a, T, S, A: Allocator> fmt::Debug for TriHashMap<T, S, A>
 where
     T: TriHashItem + fmt::Debug,
-    for<'k> T::K1<'k>: fmt::Debug,
-    for<'k> T::K2<'k>: fmt::Debug,
-    for<'k> T::K3<'k>: fmt::Debug,
+    T::K1<'a>: fmt::Debug,
+    T::K2<'a>: fmt::Debug,
+    T::K3<'a>: fmt::Debug,
+    T: 'a,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        struct KeyMap<'a, T: TriHashItem + 'a> {
-            key1: T::K1<'a>,
-            key2: T::K2<'a>,
-            key3: T::K3<'a>,
-        }
+        let mut map = f.debug_map();
+        for item in self.items.values() {
+            let key: KeyMap<'_, T> = KeyMap {
+                key1: item.key1(),
+                key2: item.key2(),
+                key3: item.key3(),
+            };
 
-        impl<'a, T: TriHashItem> fmt::Debug for KeyMap<'a, T>
-        where
-            for<'k> T::K1<'k>: fmt::Debug,
-            for<'k> T::K2<'k>: fmt::Debug,
-            for<'k> T::K3<'k>: fmt::Debug,
-        {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                // We don't want to show key1 and key2 as a tuple since it's
-                // misleading (suggests maps of tuples). The best we can do
-                // instead is to show "{k1: abc, k2: xyz, k3: def}"
-                f.debug_map()
-                    .entry(&StrDisplayAsDebug("k1"), &self.key1)
-                    .entry(&StrDisplayAsDebug("k2"), &self.key2)
-                    .entry(&StrDisplayAsDebug("k3"), &self.key3)
-                    .finish()
-            }
-        }
+            // SAFETY: We only use key within the scope of this block before
+            // immediately dropping it -- map.entry calls key.fmt() without
+            // holding a reference to it.
+            let key: KeyMap<'a, T> = unsafe {
+                core::mem::transmute::<KeyMap<'_, T>, KeyMap<'a, T>>(key)
+            };
 
+            map.entry(&key, item);
+        }
+        map.finish()
+    }
+}
+
+struct KeyMap<'a, T: TriHashItem + 'a> {
+    key1: T::K1<'a>,
+    key2: T::K2<'a>,
+    key3: T::K3<'a>,
+}
+
+impl<'a, T: TriHashItem> fmt::Debug for KeyMap<'a, T>
+where
+    T::K1<'a>: fmt::Debug,
+    T::K2<'a>: fmt::Debug,
+    T::K3<'a>: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // We don't want to show key1 and key2 as a tuple since it's
+        // misleading (suggests maps of tuples). The best we can do
+        // instead is to show "{k1: abc, k2: xyz, k3: def}"
         f.debug_map()
-            .entries(self.items.iter().map(|(_, item)| {
-                (
-                    KeyMap::<T> {
-                        key1: item.key1(),
-                        key2: item.key2(),
-                        key3: item.key3(),
-                    },
-                    item,
-                )
-            }))
+            .entry(&StrDisplayAsDebug("k1"), &self.key1)
+            .entry(&StrDisplayAsDebug("k2"), &self.key2)
+            .entry(&StrDisplayAsDebug("k3"), &self.key3)
             .finish()
     }
 }

--- a/crates/iddqd/tests/integration/bi_hash_map.rs
+++ b/crates/iddqd/tests/integration/bi_hash_map.rs
@@ -558,9 +558,9 @@ fn insert_entry_panics_for_non_matching_keys() {
 fn borrowed_item() {
     let mut map = BiHashMap::<BorrowedItem, HashBuilder, Alloc>::default();
     let item1 =
-        BorrowedItem { key1: "foo", key2: b"foo", key3: &Path::new("foo") };
+        BorrowedItem { key1: "foo", key2: b"foo", key3: Path::new("foo") };
     let item2 =
-        BorrowedItem { key1: "bar", key2: b"bar", key3: &Path::new("bar") };
+        BorrowedItem { key1: "bar", key2: b"bar", key3: Path::new("bar") };
 
     // Insert items.
     map.insert_unique(item1.clone()).unwrap();

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -2,6 +2,7 @@ use iddqd::{
     IdHashItem, IdHashMap, id_hash_map, id_upcast, internal::ValidateCompact,
 };
 use iddqd_test_utils::{
+    borrowed_item::BorrowedItem,
     eq_props::{assert_eq_props, assert_ne_props},
     naive_map::NaiveMap,
     test_item::{
@@ -10,6 +11,7 @@ use iddqd_test_utils::{
     },
 };
 use proptest::prelude::*;
+use std::path::Path;
 use test_strategy::{Arbitrary, proptest};
 
 #[derive(Clone, Debug)]
@@ -384,6 +386,43 @@ fn insert_entry_panics_for_non_matching_key() {
     } else {
         panic!("expected VacantEntry");
     }
+}
+
+#[test]
+fn borrowed_item() {
+    let mut map = IdHashMap::<BorrowedItem, HashBuilder, Alloc>::default();
+    let item1 =
+        BorrowedItem { key1: "foo", key2: b"foo", key3: &Path::new("foo") };
+    let item2 =
+        BorrowedItem { key1: "bar", key2: b"bar", key3: &Path::new("bar") };
+
+    // Insert items.
+    map.insert_unique(item1.clone()).unwrap();
+    map.insert_unique(item2.clone()).unwrap();
+
+    // Check that we can retrieve them.
+    assert_eq!(map.get("foo").unwrap().key1, "foo");
+    assert_eq!(map.get("bar").unwrap().key1, "bar");
+
+    // Check that we can iterate over them.
+    let keys: Vec<_> = map.iter().map(|item| item.key()).collect();
+    assert_eq!(keys, vec!["foo", "bar"]);
+
+    // Check that we can print a Debug representation, even within a function
+    // (supporting this requires a little bit of unsafe code to get the
+    // lifetimes to line up).
+    fn fmt_debug(
+        map: &IdHashMap<BorrowedItem<'_>, HashBuilder, Alloc>,
+    ) -> String {
+        format!("{:?}", map)
+    }
+
+    static DEBUG_OUTPUT: &str = "{\"foo\": BorrowedItem { \
+        key1: \"foo\", key2: [102, 111, 111], key3: \"foo\" }, \
+        \"bar\": BorrowedItem { \
+        key1: \"bar\", key2: [98, 97, 114], key3: \"bar\" }}";
+    assert_eq!(format!("{:?}", map), DEBUG_OUTPUT);
+    assert_eq!(fmt_debug(&map), DEBUG_OUTPUT);
 }
 
 mod macro_tests {

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -392,9 +392,9 @@ fn insert_entry_panics_for_non_matching_key() {
 fn borrowed_item() {
     let mut map = IdHashMap::<BorrowedItem, HashBuilder, Alloc>::default();
     let item1 =
-        BorrowedItem { key1: "foo", key2: b"foo", key3: &Path::new("foo") };
+        BorrowedItem { key1: "foo", key2: b"foo", key3: Path::new("foo") };
     let item2 =
-        BorrowedItem { key1: "bar", key2: b"bar", key3: &Path::new("bar") };
+        BorrowedItem { key1: "bar", key2: b"bar", key3: Path::new("bar") };
 
     // Insert items.
     map.insert_unique(item1.clone()).unwrap();

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -3,6 +3,7 @@ use iddqd::{
     internal::{ValidateChaos, ValidateCompact},
 };
 use iddqd_test_utils::{
+    borrowed_item::BorrowedItem,
     eq_props::{assert_eq_props, assert_ne_props},
     naive_map::NaiveMap,
     test_item::{
@@ -12,6 +13,7 @@ use iddqd_test_utils::{
     unwind::catch_panic,
 };
 use proptest::prelude::*;
+use std::path::Path;
 use test_strategy::{Arbitrary, proptest};
 
 #[test]
@@ -465,6 +467,42 @@ fn insert_entry_panics_for_present_key() {
     } else {
         panic!("Expected Vacant entry");
     }
+}
+
+#[test]
+fn borrowed_item() {
+    let mut map = IdOrdMap::<BorrowedItem>::default();
+    let item1 =
+        BorrowedItem { key1: "foo", key2: b"foo", key3: &Path::new("foo") };
+    let item2 =
+        BorrowedItem { key1: "bar", key2: b"bar", key3: &Path::new("bar") };
+
+    // Insert items.
+    map.insert_unique(item1.clone()).unwrap();
+    map.insert_unique(item2.clone()).unwrap();
+
+    // Check that we can retrieve them.
+    assert_eq!(map.get("foo").unwrap().key1, "foo");
+    assert_eq!(map.get("bar").unwrap().key1, "bar");
+
+    // Check that we can iterate over them.
+    let keys: Vec<_> = map.iter().map(|item| item.key()).collect();
+    assert_eq!(keys, vec!["bar", "foo"]);
+
+    // Check that we can print a Debug representation, even within a function
+    // (supporting this requires a little bit of unsafe code to get the
+    // lifetimes to line up).
+    fn fmt_debug(map: &IdOrdMap<BorrowedItem<'_>>) -> String {
+        format!("{:?}", map)
+    }
+
+    static DEBUG_OUTPUT: &str = "{\"bar\": BorrowedItem { \
+        key1: \"bar\", key2: [98, 97, 114], key3: \"bar\" }, \
+        \"foo\": BorrowedItem { \
+        key1: \"foo\", key2: [102, 111, 111], key3: \"foo\" }}";
+
+    assert_eq!(format!("{:?}", map), DEBUG_OUTPUT);
+    assert_eq!(fmt_debug(&map), DEBUG_OUTPUT);
 }
 
 mod macro_tests {

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -473,9 +473,9 @@ fn insert_entry_panics_for_present_key() {
 fn borrowed_item() {
     let mut map = IdOrdMap::<BorrowedItem>::default();
     let item1 =
-        BorrowedItem { key1: "foo", key2: b"foo", key3: &Path::new("foo") };
+        BorrowedItem { key1: "foo", key2: b"foo", key3: Path::new("foo") };
     let item2 =
-        BorrowedItem { key1: "bar", key2: b"bar", key3: &Path::new("bar") };
+        BorrowedItem { key1: "bar", key2: b"bar", key3: Path::new("bar") };
 
     // Insert items.
     map.insert_unique(item1.clone()).unwrap();

--- a/crates/iddqd/tests/integration/tri_hash_map.rs
+++ b/crates/iddqd/tests/integration/tri_hash_map.rs
@@ -437,9 +437,9 @@ fn get_mut_panics_if_key3_changes() {
 fn borrowed_item() {
     let mut map = TriHashMap::<BorrowedItem, HashBuilder, Alloc>::default();
     let item1 =
-        BorrowedItem { key1: "foo", key2: b"foo", key3: &Path::new("foo") };
+        BorrowedItem { key1: "foo", key2: b"foo", key3: Path::new("foo") };
     let item2 =
-        BorrowedItem { key1: "bar", key2: b"bar", key3: &Path::new("bar") };
+        BorrowedItem { key1: "bar", key2: b"bar", key3: Path::new("bar") };
 
     // Insert items.
     map.insert_unique(item1.clone()).unwrap();


### PR DESCRIPTION
This allows `Debug` with borrowed items to work in more circumstances.

We do have to use unsafe code, but that's okay because we have a `T: 'a` bound. This means that the key is valid for 'a, and in any case we discard the key immediately after calling its `Debug` impl.

It looks like we'll also have to do this for all the `IdOrdMap` mutable getters. That will come in the future.