### PR TITLE
relax Hash requirement on IdOrdMap

### DIFF
--- a/crates/iddqd-test-utils/src/test_item.rs
+++ b/crates/iddqd-test-utils/src/test_item.rs
@@ -568,7 +568,7 @@ where
 impl<T> ItemMap<T> for IdOrdMap<T>
 where
     T: IdOrdItem + Clone,
-    for<'k> <T as IdOrdItem>::Key<'k>: std::hash::Hash,
+    for<'k> T::Key<'k>: std::hash::Hash,
 {
     type RefMut<'a>
         = id_ord_map::RefMut<'a, T>
@@ -750,7 +750,7 @@ impl<'a, T: IdHashItem> IntoRef<'a, T>
 #[cfg(feature = "std")]
 impl<'a, T: IdOrdItem> IntoRef<'a, T> for id_ord_map::RefMut<'a, T>
 where
-    for<'k> <T as IdOrdItem>::Key<'k>: std::hash::Hash,
+    T::Key<'a>: std::hash::Hash,
 {
     fn into_ref(self) -> &'a T {
         self.into_ref()

--- a/crates/iddqd/src/id_ord_map/tables.rs
+++ b/crates/iddqd/src/id_ord_map/tables.rs
@@ -28,12 +28,13 @@ impl IdOrdMapTables {
         Ok(())
     }
 
-    pub(super) fn make_hash<T: IdOrdItem>(
+    pub(super) fn make_hash<'a, T>(
         &self,
-        item: &T,
+        item: &'a T,
     ) -> MapHash<foldhash::fast::RandomState>
     where
-        for<'k> T::Key<'k>: Hash,
+        T::Key<'a>: Hash,
+        T: 'a + IdOrdItem,
     {
         self.key_to_item.compute_hash(item.key())
     }


### PR DESCRIPTION
Like in #39, we shouldn't require `Hash` on every `'k`, just on the relevant
`'a`.

The included test code would fail to compile.
