### PR TITLE
Support schema-rs preserve-order feature

### DIFF
--- a/crates/iddqd/src/support/schemars_utils.rs
+++ b/crates/iddqd/src/support/schemars_utils.rs
@@ -2,7 +2,6 @@
 
 use alloc::{
     boxed::Box,
-    collections::BTreeMap,
     string::{String, ToString},
 };
 
@@ -57,7 +56,7 @@ where
 pub(crate) fn make_extension_table<T>(
     path: &'static str,
     generator: &mut schemars::gen::SchemaGenerator,
-) -> BTreeMap<String, serde_json::Value>
+) -> schemars::Map<String, serde_json::Value>
 where
     T: schemars::JsonSchema,
 {


### PR DESCRIPTION
Schema-rs uses the `Map` type for [`extensions`](https://github.com/GREsau/schemars/blob/104b0fd65055d4b46f8dcbe38cdd2ef2c4098fe2/schemars/src/schema.rs#L167). 

[`Map`](https://github.com/GREsau/schemars/blob/104b0fd65055d4b46f8dcbe38cdd2ef2c4098fe2/schemars/src/lib.rs#L9-L12) underlying type is actually different depending on the feature used. The `preserve-order` feature changes the type, so that this crate does no longer compile because of the return type mismatch. 

Using the `Map` "alias" does fix the compilation. 