### PR TITLE
only call self.before().key() once in IdLeaf impls

### DIFF
--- a/crates/iddqd/src/bi_hash_map/daft_impls.rs
+++ b/crates/iddqd/src/bi_hash_map/daft_impls.rs
@@ -402,7 +402,7 @@ impl<T: BiHashItem> BiHashItem for IdLeaf<T> {
         if before_key != self.after().key1() {
             panic!("key is different between before and after");
         }
-        self.before().key1()
+        before_key
     }
 
     fn key2(&self) -> Self::K2<'_> {
@@ -410,7 +410,7 @@ impl<T: BiHashItem> BiHashItem for IdLeaf<T> {
         if before_key != self.after().key2() {
             panic!("key is different between before and after");
         }
-        self.before().key2()
+        before_key
     }
 
     #[inline]

--- a/crates/iddqd/src/id_hash_map/daft_impls.rs
+++ b/crates/iddqd/src/id_hash_map/daft_impls.rs
@@ -241,7 +241,7 @@ impl<T: IdHashItem> IdHashItem for IdLeaf<T> {
         if before_key != self.after().key() {
             panic!("key is different between before and after");
         }
-        self.before().key()
+        before_key
     }
 
     #[inline]

--- a/crates/iddqd/src/id_ord_map/daft_impls.rs
+++ b/crates/iddqd/src/id_ord_map/daft_impls.rs
@@ -184,7 +184,7 @@ impl<T: IdOrdItem> IdOrdItem for IdLeaf<T> {
         if before_key != self.after().key() {
             panic!("key is different between before and after");
         }
-        self.before().key()
+        before_key
     }
 
     #[inline]

--- a/crates/iddqd/src/tri_hash_map/daft_impls.rs
+++ b/crates/iddqd/src/tri_hash_map/daft_impls.rs
@@ -505,7 +505,7 @@ impl<T: TriHashItem> TriHashItem for IdLeaf<T> {
         if before_key != self.after().key1() {
             panic!("key1 is different between before and after");
         }
-        self.before().key1()
+        before_key
     }
 
     fn key2(&self) -> Self::K2<'_> {
@@ -513,7 +513,7 @@ impl<T: TriHashItem> TriHashItem for IdLeaf<T> {
         if before_key != self.after().key2() {
             panic!("key2 is different between before and after");
         }
-        self.before().key2()
+        before_key
     }
 
     fn key3(&self) -> Self::K3<'_> {
@@ -521,7 +521,7 @@ impl<T: TriHashItem> TriHashItem for IdLeaf<T> {
         if before_key != self.after().key3() {
             panic!("key3 is different between before and after");
         }
-        self.before().key3()
+        before_key
     }
 
     #[inline]


### PR DESCRIPTION
No need to call it twice.
