### PR TITLE
[RFC] use dynamic dispatch for IdOrdMap Hash impl

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,18 @@
+experimental = ["wrapper-scripts"]
+
 [profile.default-miri]
 # proptests are too slow to be run through miri
 default-filter = "not test(proptest)"
+
+[[profile.default-miri.scripts]]
+# This test deliberately leaks memory, and freeing it within the test requires
+# unsafe code (we're deliberately restricting the test to safe Rust to
+# demonstrate how purely safe Rust can introduce a bug).
+filter = "test(static_breakage)"
+platform = "cfg(unix)"
+run-wrapper = "miri-ignore-leaks"
+
+[scripts.wrapper.miri-ignore-leaks]
+command = { command-line = "scripts/miri-ignore-leaks.sh", relative-to = "workspace-root" }
+# The target runner is Miri in this case.
+target-runner = "within-wrapper"

--- a/crates/iddqd/src/id_ord_map/ref_mut.rs
+++ b/crates/iddqd/src/id_ord_map/ref_mut.rs
@@ -2,7 +2,7 @@ use super::IdOrdItem;
 use crate::support::map_hash::MapHash;
 use core::{
     fmt,
-    hash::Hash,
+    hash::{Hash, Hasher},
     ops::{Deref, DerefMut},
 };
 
@@ -44,10 +44,7 @@ use core::{
 ///
 /// [`IdOrdMap`]: crate::IdOrdMap
 /// [birthday problem]: https://en.wikipedia.org/wiki/Birthday_problem#Probability_table
-pub struct RefMut<'a, T: IdOrdItem>
-where
-    T::Key<'a>: Hash,
-{
+pub struct RefMut<'a, T: IdOrdItem> {
     inner: Option<RefMutInner<'a, T>>,
 }
 
@@ -59,7 +56,7 @@ where
         hash: MapHash<foldhash::fast::RandomState>,
         borrowed: &'a mut T,
     ) -> Self {
-        let inner = RefMutInner { hash, borrowed };
+        let inner = RefMutInner { hash, hash_fn: T::Key::hash, borrowed };
         Self { inner: Some(inner) }
     }
 
@@ -70,28 +67,21 @@ where
     }
 }
 
-impl<'a, T: IdOrdItem> RefMut<'a, T>
-where
-    for<'k> T::Key<'k>: Hash,
-{
+impl<'a, T: IdOrdItem> RefMut<'a, T> {
     /// Borrows self into a shorter-lived `RefMut`.
     ///
     /// This `RefMut` will also check hash equality on drop.
-    ///
-    /// Note: currently, due to limitations in the Rust borrow checker, this
-    /// effectively requires that `T: 'static`. Relaxing this requirement should
-    /// be possible in principle.
-    pub fn reborrow<'b>(&'b mut self) -> RefMut<'b, T> {
+    pub fn reborrow<'b>(&'b mut self) -> RefMut<'b, T>
+    where
+        T::Key<'b>: Hash,
+    {
         let inner = self.inner.as_mut().unwrap();
         let borrowed = &mut *inner.borrowed;
         RefMut::new(inner.hash.clone(), borrowed)
     }
 }
 
-impl<'a, T: IdOrdItem> Drop for RefMut<'a, T>
-where
-    T::Key<'a>: Hash,
-{
+impl<'a, T: IdOrdItem> Drop for RefMut<'a, T> {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.take() {
             inner.into_ref();
@@ -99,10 +89,7 @@ where
     }
 }
 
-impl<'a, T: IdOrdItem> Deref for RefMut<'a, T>
-where
-    T::Key<'a>: Hash,
-{
+impl<'a, T: IdOrdItem> Deref for RefMut<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -110,19 +97,13 @@ where
     }
 }
 
-impl<'a, T: IdOrdItem> DerefMut for RefMut<'a, T>
-where
-    T::Key<'a>: Hash,
-{
+impl<'a, T: IdOrdItem> DerefMut for RefMut<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.as_mut().unwrap().borrowed
     }
 }
 
-impl<'a, T: IdOrdItem + fmt::Debug> fmt::Debug for RefMut<'a, T>
-where
-    T::Key<'a>: Hash,
-{
+impl<'a, T: IdOrdItem + fmt::Debug> fmt::Debug for RefMut<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.inner {
             Some(ref inner) => inner.fmt(f),
@@ -135,20 +116,30 @@ where
 
 struct RefMutInner<'a, T: IdOrdItem> {
     hash: MapHash<foldhash::fast::RandomState>,
+    // Store the hash function here so that type signatures aren't polluted with
+    // T::Key<'a>: Hash everywhere. (A Drop impl, which is where the hash is
+    // checked, cannot have stricter trait bounds than the type declaration.)
+    //
+    // We do pay the cost of dynamic dispatch here (i.e. not being able to
+    // inline the hash function), but not having to say `T::Key<'a>: Hash`
+    // everywhere allows `reborrow` to work against a non-'static T.
+    hash_fn: fn(&T::Key<'a>, &mut foldhash::fast::FoldHasher),
     borrowed: &'a mut T,
 }
 
-impl<'a, T: IdOrdItem> RefMutInner<'a, T>
-where
-    T::Key<'a>: Hash,
-{
+impl<'a, T: IdOrdItem> RefMutInner<'a, T> {
     fn into_ref(self) -> &'a T {
         let key: T::Key<'_> = self.borrowed.key();
         // SAFETY: The key is borrowed, then dropped immediately. T is valid for
         // 'a so T::Key is valid for 'a.
         let key: T::Key<'a> =
             unsafe { std::mem::transmute::<T::Key<'_>, T::Key<'a>>(key) };
-        if !self.hash.is_same_hash(&key) {
+
+        let mut hasher = self.hash.build_hasher();
+        (self.hash_fn)(&key, &mut hasher);
+        let hash = hasher.finish();
+
+        if self.hash.hash() != hash {
             panic!("key changed during RefMut borrow");
         }
 

--- a/crates/iddqd/src/support/map_hash.rs
+++ b/crates/iddqd/src/support/map_hash.rs
@@ -19,6 +19,16 @@ impl<S> fmt::Debug for MapHash<S> {
 }
 
 impl<S: BuildHasher> MapHash<S> {
+    #[inline]
+    pub(crate) fn build_hasher(&self) -> S::Hasher {
+        self.state.build_hasher()
+    }
+
+    #[inline]
+    pub(crate) fn hash(&self) -> u64 {
+        self.hash
+    }
+
     pub(crate) fn is_same_hash<K: Hash>(&self, key: K) -> bool {
         self.hash == self.state.hash_one(key)
     }

--- a/crates/iddqd/src/support/map_hash.rs
+++ b/crates/iddqd/src/support/map_hash.rs
@@ -21,8 +21,8 @@ impl<S> fmt::Debug for MapHash<S> {
 impl<S: BuildHasher> MapHash<S> {
     #[cfg(feature = "std")]
     #[inline]
-    pub(crate) fn build_hasher(&self) -> S::Hasher {
-        self.state.build_hasher()
+    pub(crate) fn into_state(self) -> S {
+        self.state
     }
 
     #[cfg(feature = "std")]

--- a/crates/iddqd/src/support/map_hash.rs
+++ b/crates/iddqd/src/support/map_hash.rs
@@ -19,11 +19,13 @@ impl<S> fmt::Debug for MapHash<S> {
 }
 
 impl<S: BuildHasher> MapHash<S> {
+    #[cfg(feature = "std")]
     #[inline]
     pub(crate) fn build_hasher(&self) -> S::Hasher {
         self.state.build_hasher()
     }
 
+    #[cfg(feature = "std")]
     #[inline]
     pub(crate) fn hash(&self) -> u64 {
         self.hash

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -518,6 +518,20 @@ fn borrowed_item() {
     assert_eq!(map.get("foo").unwrap().key1, "foo");
     assert_eq!(map.get("bar").unwrap().key1, "bar");
 
+    // Check that we can mutably retrieve them.
+    {
+        let mut item1 = map.get_mut("foo").unwrap();
+        item1.key2 = b"foo2";
+
+        // Including reborrows.
+        {
+            let mut item1_reborrowed = item1.reborrow();
+            item1_reborrowed.key3 = Path::new("foo2");
+        }
+
+        item1.key2 = b"foo3";
+    }
+
     // Check that we can iterate over them.
     let keys: Vec<_> = map.iter().map(|item| item.key()).collect();
     assert_eq!(keys, vec!["bar", "foo"]);

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -673,9 +673,8 @@ fn proptest_arbitrary_map(map: IdOrdMap<TestItem>) {
 }
 
 mod static_breakage {
-    use std::hash::Hash;
-
     use super::*;
+    use std::hash::Hash;
 
     struct Item {
         id: String,

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -546,7 +546,7 @@ fn borrowed_item() {
     static DEBUG_OUTPUT: &str = "{\"bar\": BorrowedItem { \
         key1: \"bar\", key2: [98, 97, 114], key3: \"bar\" }, \
         \"foo\": BorrowedItem { \
-        key1: \"foo\", key2: [102, 111, 111], key3: \"foo\" }}";
+        key1: \"foo\", key2: [102, 111, 111, 51], key3: \"foo2\" }}";
 
     assert_eq!(format!("{map:?}"), DEBUG_OUTPUT);
     assert_eq!(fmt_debug(&map), DEBUG_OUTPUT);

--- a/scripts/miri-ignore-leaks.sh
+++ b/scripts/miri-ignore-leaks.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# A nextest wrapper script that instructs Miri to ignore leaks.
+
+MIRIFLAGS="${MIRIFLAGS} -Zmiri-ignore-leaks" "$@"


### PR DESCRIPTION
This allows `reborrow` to work against borrowed data (though based on https://github.com/rust-lang/rust/issues/92985 the new Polonius implementation would also solve this issue), and means that the type definition doesn't have to carry around the `Hash` restriction.

As one might expect from dynamic dispatch, this does slow down the benchmark:

```
before:
id_ord_map_ref_mut_simple
                        time:   [72.419 ns 72.574 ns 72.739 ns]

after:
id_ord_map_ref_mut_simple
                        time:   [79.710 ns 79.984 ns 80.263 ns]
                        change: [+8.2749% +9.6421% +11.091%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

So it's a judgment call about whether we should go in this direction.
