### PR TITLE
[DNM] construct hasher at RefMut construction time

### DIFF
--- a/crates/iddqd/src/support/map_hash.rs
+++ b/crates/iddqd/src/support/map_hash.rs
@@ -19,6 +19,18 @@ impl<S> fmt::Debug for MapHash<S> {
 }
 
 impl<S: BuildHasher> MapHash<S> {
+    #[cfg(feature = "std")]
+    #[inline]
+    pub(crate) fn build_hasher(&self) -> S::Hasher {
+        self.state.build_hasher()
+    }
+
+    #[cfg(feature = "std")]
+    #[inline]
+    pub(crate) fn hash(&self) -> u64 {
+        self.hash
+    }
+
     pub(crate) fn is_same_hash<K: Hash>(&self, key: K) -> bool {
         self.hash == self.state.hash_one(key)
     }


### PR DESCRIPTION
Because of what I think is the size of the hasher struct, this is actually slightly slower:

```
before:
id_ord_map_ref_mut_simple
                        time:   [73.245 ns 73.403 ns 73.575 ns]

after:
id_ord_map_ref_mut_simple
                        time:   [74.926 ns 75.103 ns 75.251 ns]
                        change: [+0.7075% +1.9370% +3.2981%] (p = 0.00 < 0.05)
```
