### PR TITLE
[RFC] use dynamic dispatch for IdOrdMap Hash impl

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,18 @@
+experimental = ["wrapper-scripts"]
+
 [profile.default-miri]
 # proptests are too slow to be run through miri
 default-filter = "not test(proptest)"
+
+[[profile.default-miri.scripts]]
+# This test deliberately leaks memory, and freeing it within the test requires
+# unsafe code (we're deliberately restricting the test to safe Rust to
+# demonstrate how purely safe Rust can introduce a bug).
+filter = "test(static_breakage)"
+platform = "cfg(unix)"
+run-wrapper = "miri-ignore-leaks"
+
+[scripts.wrapper.miri-ignore-leaks]
+command = { command-line = "scripts/miri-ignore-leaks.sh", relative-to = "workspace-root" }
+# The target runner is Miri in this case.
+target-runner = "within-wrapper"

--- a/crates/iddqd/src/support/map_hash.rs
+++ b/crates/iddqd/src/support/map_hash.rs
@@ -19,6 +19,18 @@ impl<S> fmt::Debug for MapHash<S> {
 }
 
 impl<S: BuildHasher> MapHash<S> {
+    #[cfg(feature = "std")]
+    #[inline]
+    pub(crate) fn into_state(self) -> S {
+        self.state
+    }
+
+    #[cfg(feature = "std")]
+    #[inline]
+    pub(crate) fn hash(&self) -> u64 {
+        self.hash
+    }
+
     pub(crate) fn is_same_hash<K: Hash>(&self, key: K) -> bool {
         self.hash == self.state.hash_one(key)
     }

--- a/scripts/miri-ignore-leaks.sh
+++ b/scripts/miri-ignore-leaks.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# A nextest wrapper script that instructs Miri to ignore leaks.
+
+MIRIFLAGS="${MIRIFLAGS} -Zmiri-ignore-leaks" "$@"


### PR DESCRIPTION
This allows `reborrow` to work against borrowed data (though based on https://github.com/rust-lang/rust/issues/92985 the new Polonius implementation would also solve this issue), and means that the type definition doesn't have to carry around the `Hash` restriction.

As one might expect from dynamic dispatch, this does slow down the benchmark:

```
before:
id_ord_map_ref_mut_simple
                        time:   [72.419 ns 72.574 ns 72.739 ns]

after:
id_ord_map_ref_mut_simple
                        time:   [79.710 ns 79.984 ns 80.263 ns]
                        change: [+8.2749% +9.6421% +11.091%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

So it's a judgment call about whether we should go in this direction.
