### PR TITLE
refactor: relax bounds on struct definitions

### DIFF
--- a/crates/iddqd/src/bi_hash_map/imp.rs
+++ b/crates/iddqd/src/bi_hash_map/imp.rs
@@ -76,11 +76,7 @@ use hashbrown::hash_table;
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct BiHashMap<
-    T: BiHashItem,
-    S = DefaultHashBuilder,
-    A: Allocator = Global,
-> {
+pub struct BiHashMap<T, S = DefaultHashBuilder, A: Allocator = Global> {
     pub(super) items: ItemSet<T, A>,
     // Invariant: the values (usize) in these tables are valid indexes into
     // `items`, and are a 1:1 mapping.

--- a/crates/iddqd/src/id_hash_map/imp.rs
+++ b/crates/iddqd/src/id_hash_map/imp.rs
@@ -64,11 +64,7 @@ use hashbrown::hash_table;
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct IdHashMap<
-    T: IdHashItem,
-    S = DefaultHashBuilder,
-    A: Allocator = Global,
-> {
+pub struct IdHashMap<T, S = DefaultHashBuilder, A: Allocator = Global> {
     pub(super) items: ItemSet<T, A>,
     tables: IdHashMapTables<S, A>,
 }

--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -57,7 +57,7 @@ use equivalent::{Comparable, Equivalent};
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct IdOrdMap<T: IdOrdItem> {
+pub struct IdOrdMap<T> {
     // We don't expose an allocator trait here because it isn't stable with
     // std's BTreeMap.
     pub(super) items: ItemSet<T, Global>,

--- a/crates/iddqd/src/tri_hash_map/imp.rs
+++ b/crates/iddqd/src/tri_hash_map/imp.rs
@@ -82,11 +82,7 @@ use hashbrown::hash_table::{Entry, VacantEntry};
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct TriHashMap<
-    T: TriHashItem,
-    S = DefaultHashBuilder,
-    A: Allocator = Global,
-> {
+pub struct TriHashMap<T, S = DefaultHashBuilder, A: Allocator = Global> {
     pub(super) items: ItemSet<T, A>,
     // Invariant: the values (usize) in these tables are valid indexes into
     // `items`, and are a 1:1 mapping.


### PR DESCRIPTION
It's uncommon to place bounds on structs unless the trait is needed for rustc to compute the layout.
e.g required for [`iter::Peekable`](https://doc.rust-lang.org/beta/std/iter/struct.Peekable.html) but not for [`collections::HashMap`](https://doc.rust-lang.org/beta/std/collections/struct.HashMap.html).

This change means I can stop polluting my own generic structs with trait bounds, and only put bounds where the behaviour requires it.

I think this is backwards compatible.