### PR TITLE
[iddqd-benches] add benches for get functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ name = "iddqd-benches"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "foldhash 0.2.0",
  "iddqd",
  "iddqd-test-utils",
 ]

--- a/crates/iddqd-benches/Cargo.toml
+++ b/crates/iddqd-benches/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 criterion.workspace = true
+foldhash.workspace = true
 iddqd = { workspace = true, features = ["std"] }
 iddqd-test-utils = { workspace = true, features = ["std"] }
 

--- a/crates/iddqd-benches/Cargo.toml
+++ b/crates/iddqd-benches/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 criterion.workspace = true
 foldhash.workspace = true
-iddqd = { workspace = true, features = ["std"] }
+iddqd = { workspace = true, features = ["default-hasher", "std"] }
 iddqd-test-utils = { workspace = true, features = ["std"] }
 
 [lints]

--- a/crates/iddqd-benches/benches/benches.rs
+++ b/crates/iddqd-benches/benches/benches.rs
@@ -4,8 +4,10 @@
 //! live here.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use iddqd::IdOrdMap;
+use iddqd::{DefaultHashBuilder, IdHashMap, IdOrdMap};
+use iddqd_benches::{RecordBorrowedU32, RecordOwnedU32};
 use iddqd_test_utils::test_item::{TestItem, TestKey1};
+use std::collections::{BTreeMap, HashMap};
 
 fn bench_fn(c: &mut Criterion) {
     // Benchmark the id_ord_map::RefMut implementation with a very simple hash
@@ -16,8 +18,7 @@ fn bench_fn(c: &mut Criterion) {
     c.bench_function("id_ord_map_ref_mut_simple", |b| {
         b.iter_batched(
             || {
-                //
-                // Create a new IdOrdMap instance
+                // Create a new IdOrdMap instance.
                 let mut map = IdOrdMap::new();
                 map.insert_overwrite(TestItem::new(1, 'a', "foo", "bar"));
                 map
@@ -26,6 +27,137 @@ fn bench_fn(c: &mut Criterion) {
                 let mut item = map.get_mut(&TestKey1::new(&1)).unwrap();
                 item.key2 = 'b';
                 drop(item);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("hash_map_u32_get", |b| {
+        b.iter_batched(
+            || {
+                let mut map =
+                    HashMap::with_hasher(DefaultHashBuilder::default());
+                map.insert(
+                    0u32,
+                    RecordOwnedU32 { index: 0, data: "data".to_owned() },
+                );
+                map.insert(
+                    1u32,
+                    RecordOwnedU32 { index: 1, data: "data1".to_owned() },
+                );
+                map
+            },
+            |map| {
+                map.get(&0);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("id_hash_map_owned_u32_get", |b| {
+        b.iter_batched(
+            || {
+                // Create a new IdHashMap instance.
+                let mut map = IdHashMap::new();
+                map.insert_overwrite(RecordOwnedU32 {
+                    index: 0,
+                    data: "data".to_owned(),
+                });
+                map.insert_overwrite(RecordOwnedU32 {
+                    index: 1,
+                    data: "data1".to_owned(),
+                });
+                map
+            },
+            |map| {
+                map.get(&0);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("id_hash_map_borrowed_u32_get", |b| {
+        b.iter_batched(
+            || {
+                // Create a new IdHashMap instance.
+                let mut map = IdHashMap::new();
+                map.insert_overwrite(RecordBorrowedU32 {
+                    index: 0,
+                    data: "data".to_owned(),
+                });
+                map.insert_overwrite(RecordBorrowedU32 {
+                    index: 1,
+                    data: "data1".to_owned(),
+                });
+                map
+            },
+            |map| {
+                map.get(&0);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("btree_map_u32_get", |b| {
+        b.iter_batched(
+            || {
+                let mut map = BTreeMap::new();
+                map.insert(
+                    0u32,
+                    RecordOwnedU32 { index: 0, data: "data".to_owned() },
+                );
+                map.insert(
+                    1u32,
+                    RecordOwnedU32 { index: 1, data: "data1".to_owned() },
+                );
+                map
+            },
+            |map| {
+                map.get(&0);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("id_ord_map_owned_u32_get", |b| {
+        b.iter_batched(
+            || {
+                // Create a new IdHashMap instance.
+                let mut map = IdOrdMap::new();
+                map.insert_overwrite(RecordOwnedU32 {
+                    index: 0,
+                    data: "data".to_owned(),
+                });
+                map.insert_overwrite(RecordOwnedU32 {
+                    index: 1,
+                    data: "data1".to_owned(),
+                });
+                map
+            },
+            |map| {
+                map.get(&0);
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("id_ord_map_borrowed_u32_get", |b| {
+        b.iter_batched(
+            || {
+                // Create a new IdHashMap instance.
+                let mut map = IdOrdMap::new();
+                map.insert_overwrite(RecordBorrowedU32 {
+                    index: 0,
+                    data: "data".to_owned(),
+                });
+                map.insert_overwrite(RecordBorrowedU32 {
+                    index: 1,
+                    data: "data1".to_owned(),
+                });
+                map
+            },
+            |map| {
+                map.get(&0);
             },
             criterion::BatchSize::SmallInput,
         );

--- a/crates/iddqd-benches/src/lib.rs
+++ b/crates/iddqd-benches/src/lib.rs
@@ -1,1 +1,51 @@
+use iddqd::{IdHashItem, IdOrdItem, id_upcast};
 
+pub struct RecordOwnedU32 {
+    pub index: u32,
+    pub data: String,
+}
+
+impl IdHashItem for RecordOwnedU32 {
+    type Key<'a> = u32;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.index
+    }
+
+    id_upcast!();
+}
+
+impl IdOrdItem for RecordOwnedU32 {
+    type Key<'a> = u32;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.index
+    }
+
+    id_upcast!();
+}
+
+pub struct RecordBorrowedU32 {
+    pub index: u32,
+    pub data: String,
+}
+
+impl IdHashItem for RecordBorrowedU32 {
+    type Key<'a> = &'a u32;
+
+    fn key(&self) -> Self::Key<'_> {
+        &self.index
+    }
+
+    id_upcast!();
+}
+
+impl IdOrdItem for RecordBorrowedU32 {
+    type Key<'a> = &'a u32;
+
+    fn key(&self) -> Self::Key<'_> {
+        &self.index
+    }
+
+    id_upcast!();
+}


### PR DESCRIPTION
iddqd is definitely a bit slower due to the multiple lookups required, but it's still quite competitive overall.

```
hash_map_u32_get        time:   [29.941 ns 30.200 ns 30.568 ns]
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low severe
  2 (2.00%) high mild
  4 (4.00%) high severe

id_hash_map_owned_u32_get
                        time:   [49.183 ns 49.419 ns 49.648 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low severe

id_hash_map_borrowed_u32_get
                        time:   [46.885 ns 46.914 ns 46.941 ns]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

btree_map_u32_get       time:   [36.684 ns 37.176 ns 37.662 ns]
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) low severe
  1 (1.00%) high severe

id_ord_map_owned_u32_get
                        time:   [51.760 ns 51.872 ns 51.987 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low severe

id_ord_map_borrowed_u32_get
                        time:   [50.047 ns 50.128 ns 50.203 ns]
Found 17 outliers among 100 measurements (17.00%)
  6 (6.00%) low severe
  5 (5.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe
```