### PR TITLE
feat: RefMut::into_mut_unchecked

### DIFF
--- a/crates/iddqd/src/bi_hash_map/ref_mut.rs
+++ b/crates/iddqd/src/bi_hash_map/ref_mut.rs
@@ -69,6 +69,13 @@ impl<'a, T: BiHashItem, S: Clone + BuildHasher> RefMut<'a, T, S> {
         let inner = self.inner.take().unwrap();
         inner.into_ref()
     }
+    /// Opt-out of the change-detection provided by [`RefMut`].
+    ///
+    /// It is a logic error to alter [`T::K1`](BiHashItem::K1)
+    /// or [`T::K2`](BiHashItem::K2) of the returned item.
+    pub fn into_mut_unchecked(mut self) -> &'a mut T {
+        self.inner.take().unwrap().borrowed
+    }
 }
 
 impl<T: BiHashItem, S: Clone + BuildHasher> Drop for RefMut<'_, T, S> {

--- a/crates/iddqd/src/id_hash_map/ref_mut.rs
+++ b/crates/iddqd/src/id_hash_map/ref_mut.rs
@@ -70,6 +70,12 @@ impl<'a, T: IdHashItem, S: Clone + BuildHasher> RefMut<'a, T, S> {
         let inner = self.inner.take().unwrap();
         inner.into_ref()
     }
+    /// Opt-out of the change-detection provided by [`RefMut`].
+    ///
+    /// It is a logic error to alter [`T::Key`](IdHashItem::Key) of the returned item.
+    pub fn into_mut_unchecked(mut self) -> &'a mut T {
+        self.inner.take().unwrap().borrowed
+    }
 }
 
 impl<T: IdHashItem, S: Clone + BuildHasher> Drop for RefMut<'_, T, S> {

--- a/crates/iddqd/src/id_ord_map/ref_mut.rs
+++ b/crates/iddqd/src/id_ord_map/ref_mut.rs
@@ -68,6 +68,13 @@ where
         let inner = self.inner.take().unwrap();
         inner.into_ref()
     }
+
+    /// Opt-out of the change-detection provided by [`RefMut`].
+    ///
+    /// It is a logic error to alter [`T::Key`](IdOrdItem::Key) of the returned item.
+    pub fn into_mut_unchecked(mut self) -> &'a mut T {
+        self.inner.take().unwrap().borrowed
+    }
 }
 
 impl<'a, T: for<'k> IdOrdItemMut<'k>> RefMut<'a, T> {

--- a/crates/iddqd/src/tri_hash_map/ref_mut.rs
+++ b/crates/iddqd/src/tri_hash_map/ref_mut.rs
@@ -70,6 +70,13 @@ impl<'a, T: TriHashItem, S: Clone + BuildHasher> RefMut<'a, T, S> {
         let inner = self.inner.take().unwrap();
         inner.into_ref()
     }
+    /// Opt-out of the change-detection provided by [`RefMut`].
+    ///
+    /// It is a logic error to alter [`T::K1`](TriHashItem::K1), [`T::K2`](TriHashItem::K2),
+    /// or [`T::K3`](TriHashItem::K3) of the returned item.
+    pub fn into_mut_unchecked(mut self) -> &'a mut T {
+        self.inner.take().unwrap().borrowed
+    }
 }
 
 impl<T: TriHashItem, S: Clone + BuildHasher> Drop for RefMut<'_, T, S> {


### PR DESCRIPTION
My usecase is
```
pub struct Yak {
    id: YakId,
    pub name: String,
}
impl Yak {
    fn id(&self) -> YakId;
}
struct YakMgr(iddqd::IdHashMap<Yak>);
impl YakMgr {
    fn get_mut(&mut self, id: YakId) -> &mut Yak;
}
```

Users have no access to `id`