### PR TITLE
[integration-tests] add tests to trigger RefMut aliasing, run miri with SB+TB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,30 @@ jobs:
         run: cross check --target thumbv7em-none-eabi --no-default-features -p iddqd
 
   miri:
-    name: Run tests with miri
+    name: Run tests with miri (${{ matrix.aliasing-model }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run miri under both Stacked and Tree Borrows.
+        # 
+        # * Stacked Borrows is the default and catches most issues,
+        #   but is known to have false positives under the eventual
+        #   Rust aliasing model.
+        # * Tree Borrows is generally more permissive than Stacked
+        #   Borrows, but is stricter for some things as well. In any
+        #   case, it is likely closer to the formal model Rust is moving
+        #   towards.
+        # 
+        # We ensure in CI that iddqd satisfies both models.
+        include:
+          - aliasing-model: stacked-borrows
+            miri-flags: ""
+          - aliasing-model: tree-borrows
+            miri-flags: "-Zmiri-tree-borrows"
     env:
       RUSTFLAGS: -D warnings
+      MIRIFLAGS: ${{ matrix.miri-flags }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: dtolnay/rust-toolchain@master
@@ -106,6 +126,8 @@ jobs:
           toolchain: nightly
           components: miri
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: miri-${{ matrix.aliasing-model }}
       - uses: taiki-e/install-action@cargo-hack
       - uses: taiki-e/install-action@nextest
       # Run tests for all crates containing unsafe code. Currently, that's just

--- a/crates/iddqd/tests/integration/bi_hash_map.rs
+++ b/crates/iddqd/tests/integration/bi_hash_map.rs
@@ -155,6 +155,27 @@ fn test_insert_unique() {
     assert_eq!(map.remove_unique(&v4.key1(), &v4.key2()), Some(v4));
 }
 
+// Test that the unsafe block within RefMut doesn't trip up miri.
+#[test]
+fn test_ref_mut_aliasing() {
+    let mut map = BiHashMap::<TestItem, HashBuilder, Alloc>::make_new();
+    for i in 0..16_u8 {
+        let key2 = (b'a' + i) as char;
+        map.insert_unique(TestItem::new(i, key2, "x", "v")).unwrap();
+    }
+
+    let mut items: Vec<_> = map.iter_mut().collect();
+    for (i, item) in items.iter_mut().enumerate() {
+        item.value = format!("written-{i}");
+    }
+    drop(items);
+
+    for i in 0..16_u8 {
+        let item = map.get1(&TestKey1::new(&i)).unwrap();
+        assert!(item.value.starts_with("written-"));
+    }
+}
+
 #[test]
 fn test_extend() {
     let mut map = BiHashMap::<TestItem, HashBuilder, Alloc>::make_new();

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -139,6 +139,26 @@ fn test_insert_unique() {
     assert_eq!(*e2, v1);
 }
 
+// Test that the unsafe block within RefMut doesn't trip up miri.
+#[test]
+fn test_ref_mut_aliasing() {
+    let mut map = IdHashMap::<TestItem, HashBuilder, Alloc>::make_new();
+    for i in 0..16_u8 {
+        map.insert_unique(TestItem::new(i, 'a', "x", "v")).unwrap();
+    }
+
+    let mut items: Vec<_> = map.iter_mut().collect();
+    for (i, item) in items.iter_mut().enumerate() {
+        item.value = format!("written-{i}");
+    }
+    drop(items);
+
+    for i in 0..16_u8 {
+        let item = map.get(&TestKey1::new(&i)).unwrap();
+        assert!(item.value.starts_with("written-"));
+    }
+}
+
 #[test]
 fn test_extend() {
     let mut map = IdHashMap::<TestItem, HashBuilder, Alloc>::make_new();

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -188,6 +188,26 @@ fn test_insert_unique() {
     assert_eq!(*e2, v1);
 }
 
+// Test that the unsafe block within RefMut doesn't trip up miri.
+#[test]
+fn test_ref_mut_aliasing() {
+    let mut map = IdOrdMap::<TestItem>::make_new();
+    for i in 0..16_u8 {
+        map.insert_unique(TestItem::new(i, 'a', "x", "v")).unwrap();
+    }
+
+    let mut items: Vec<_> = map.iter_mut().collect();
+    for (i, item) in items.iter_mut().enumerate() {
+        item.value = format!("written-{i}");
+    }
+    drop(items);
+
+    for i in 0..16_u8 {
+        let item = map.get(&TestKey1::new(&i)).unwrap();
+        assert_eq!(item.value, format!("written-{}", i as usize));
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CompactnessChange {
     /// The operation makes the map non-compact.

--- a/crates/iddqd/tests/integration/tri_hash_map.rs
+++ b/crates/iddqd/tests/integration/tri_hash_map.rs
@@ -202,6 +202,28 @@ fn test_insert_unique() {
     assert_eq!(map.remove_unique(&v5.key1(), &v5.key2(), &v5.key3()), Some(v5));
 }
 
+// Test that the unsafe block within RefMut doesn't trip up miri.
+#[test]
+fn test_ref_mut_aliasing() {
+    let mut map = TriHashMap::<TestItem, HashBuilder, Alloc>::make_new();
+    for i in 0..16_u8 {
+        let key2 = (b'a' + i) as char;
+        let key3 = format!("k{i}");
+        map.insert_unique(TestItem::new(i, key2, key3, "v")).unwrap();
+    }
+
+    let mut items: Vec<_> = map.iter_mut().collect();
+    for (i, item) in items.iter_mut().enumerate() {
+        item.value = format!("written-{i}");
+    }
+    drop(items);
+
+    for i in 0..16_u8 {
+        let item = map.get1(&TestKey1::new(&i)).unwrap();
+        assert!(item.value.starts_with("written-"));
+    }
+}
+
 // Example-based test for insert_overwrite.
 //
 // Can be used to write down examples seen from the property-based operation


### PR DESCRIPTION
Ensure that iddqd's RefMut logic is sound under both Stacked and Tree Borrows.
