### PR TITLE
ensure panics during remove leave maps in a consistent state

### DIFF
--- a/crates/iddqd/README.md
+++ b/crates/iddqd/README.md
@@ -256,9 +256,13 @@ This crate is validated through a combination of:
 * Unit tests
 * Property-based tests using a naive map as an oracle
 * Chaos tests for several kinds of buggy `Eq` and `Ord` implementations
+* Explicit tests for panic safety in some scenarios
 * Miri tests for unsafe code
 
 If you see a gap in testing, new tests are welcome. Thank you!
+
+Note that **testing requires [cargo-nextest](https://nexte.st/)**: several
+tests depend on nextest’s process-per-test model.
 
 ## No-std compatibility
 

--- a/crates/iddqd/src/bi_hash_map/imp.rs
+++ b/crates/iddqd/src/bi_hash_map/imp.rs
@@ -2179,39 +2179,39 @@ impl<T: BiHashItem, S: Clone + BuildHasher, A: Allocator> BiHashMap<T, S, A> {
     }
 
     pub(super) fn remove_by_index(&mut self, remove_index: usize) -> Option<T> {
-        let value = self.items.remove(remove_index)?;
-
-        // Remove the value from the tables.
+        // For panic safety, look up both table entries while `self.items` still
+        // holds the value, then remove from both tables and items in sequence.
+        // hashbrown's `find_entry` is panic-safe under user-`Hash`/`Eq` panics
+        // (the table is not mutated until `OccupiedEntry::remove` is called),
+        // so a panic during the lookups leaves items and both tables
+        // unmodified.
+        let item = self.items.get(remove_index)?;
+        let key1 = item.key1();
+        let key2 = item.key2();
         let state = &self.tables.state;
-        let Ok(item1) =
-            self.tables.k1_to_item.find_entry(state, &value.key1(), |index| {
-                if index == remove_index {
-                    value.key1()
-                } else {
-                    self.items[index].key1()
-                }
-            })
+        let Ok(entry1) =
+            self.tables
+                .k1_to_item
+                .find_entry(state, &key1, |index| self.items[index].key1())
         else {
-            // The item was not found.
             panic!("remove_index {remove_index} not found in k1_to_item");
         };
-        let Ok(item2) =
-            self.tables.k2_to_item.find_entry(state, &value.key2(), |index| {
-                if index == remove_index {
-                    value.key2()
-                } else {
-                    self.items[index].key2()
-                }
-            })
+        let Ok(entry2) =
+            self.tables
+                .k2_to_item
+                .find_entry(state, &key2, |index| self.items[index].key2())
         else {
-            // The item was not found.
-            panic!("remove_index {remove_index} not found in k2_to_item")
+            panic!("remove_index {remove_index} not found in k2_to_item");
         };
-
-        item1.remove();
-        item2.remove();
-
-        Some(value)
+        // Drop the keys so that `self.items` can be mutated below.
+        drop((key1, key2));
+        entry1.remove();
+        entry2.remove();
+        Some(
+            self.items
+                .remove(remove_index)
+                .expect("items[remove_index] was Occupied above"),
+        )
     }
 
     pub(super) fn replace_at_indexes(

--- a/crates/iddqd/src/id_hash_map/imp.rs
+++ b/crates/iddqd/src/id_hash_map/imp.rs
@@ -1181,35 +1181,9 @@ impl<T: IdHashItem, S: Clone + BuildHasher, A: Allocator> IdHashMap<T, S, A> {
             let remove_index = map.find_index(key)?;
             (dormant_map, remove_index)
         };
-
         // SAFETY: `map` is not used after this point.
         let awakened_map = unsafe { dormant_map.awaken() };
-
-        let value = awakened_map
-            .items
-            .remove(remove_index)
-            .expect("items missing key1 that was just retrieved");
-
-        // Remove the value from the tables.
-        let state = &awakened_map.tables.state;
-        let Ok(item1) = awakened_map.tables.key_to_item.find_entry(
-            state,
-            &value.key(),
-            |index| {
-                if index == remove_index {
-                    value.key()
-                } else {
-                    awakened_map.items[index].key()
-                }
-            },
-        ) else {
-            // The item was not found.
-            panic!("we just looked this item up");
-        };
-
-        item1.remove();
-
-        Some(value)
+        awakened_map.remove_by_index(remove_index)
     }
 
     /// Retrieves an entry by its key.
@@ -1446,26 +1420,29 @@ impl<T: IdHashItem, S: Clone + BuildHasher, A: Allocator> IdHashMap<T, S, A> {
     }
 
     pub(super) fn remove_by_index(&mut self, remove_index: usize) -> Option<T> {
-        let value = self.items.remove(remove_index)?;
-
-        // Remove the value from the tables.
+        // For panic safety, look up the table entry while `self.items` still
+        // holds the value, then remove from the table and items in sequence.
+        // hashbrown's `find_entry` is panic-safe under user-`Hash`/`Eq` panics
+        // (the table is not mutated until `OccupiedEntry::remove` is called),
+        // so a panic during the lookup leaves both items and the table
+        // unmodified.
+        let key = self.items.get(remove_index)?.key();
         let state = &self.tables.state;
         let Ok(item) =
-            self.tables.key_to_item.find_entry(state, &value.key(), |index| {
-                if index == remove_index {
-                    value.key()
-                } else {
-                    self.items[index].key()
-                }
-            })
+            self.tables
+                .key_to_item
+                .find_entry(state, &key, |index| self.items[index].key())
         else {
-            // The item was not found.
             panic!("we just looked this item up");
         };
-
+        // Drop the key so that `self.items` can be mutated below.
+        drop(key);
         item.remove();
-
-        Some(value)
+        Some(
+            self.items
+                .remove(remove_index)
+                .expect("items[remove_index] was Occupied above"),
+        )
     }
 
     pub(super) fn replace_at_index(&mut self, index: usize, value: T) -> T {

--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -1437,18 +1437,25 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     }
 
     pub(super) fn remove_by_index(&mut self, remove_index: usize) -> Option<T> {
-        let value = self.items.remove(remove_index)?;
-
-        // Remove the value from the table.
-        self.tables.key_to_item.remove(remove_index, value.key(), |index| {
-            if index == remove_index {
-                value.key()
-            } else {
-                self.items[index].key()
-            }
-        });
-
-        Some(value)
+        // For panic safety, read the key while self.items still holds the slot,
+        // then remove from the B-tree *before* mutating self.items.
+        //
+        // `BTreeSet::remove` is panic-safe under user-`Ord` panics, since
+        // comparator panics during the internal binary search abort the
+        // operation without modifying the tree. (This is not a documented
+        // guarantee, but really the only reasonable way to implement a
+        // panic-safe B-tree map.) This means that a panic at this point leaves
+        // both items and the B-tree unmodified. `items.remove` afterwards
+        // cannot panic.
+        let key = self.items.get(remove_index)?.key();
+        self.tables
+            .key_to_item
+            .remove(remove_index, key, |index| self.items[index].key());
+        Some(
+            self.items
+                .remove(remove_index)
+                .expect("items[remove_index] was Occupied above"),
+        )
     }
 
     pub(super) fn replace_at_index(&mut self, index: usize, value: T) -> T {

--- a/crates/iddqd/src/lib.rs
+++ b/crates/iddqd/src/lib.rs
@@ -284,9 +284,13 @@
 //! * Unit tests
 //! * Property-based tests using a naive map as an oracle
 //! * Chaos tests for several kinds of buggy `Eq` and `Ord` implementations
+//! * Explicit tests for panic safety in some scenarios
 //! * Miri tests for unsafe code
 //!
 //! If you see a gap in testing, new tests are welcome. Thank you!
+//!
+//! Note that **testing requires [cargo-nextest](https://nexte.st/)**: several
+//! tests depend on nextest's process-per-test model.
 //!
 //! # No-std compatibility
 //!

--- a/crates/iddqd/src/tri_hash_map/imp.rs
+++ b/crates/iddqd/src/tri_hash_map/imp.rs
@@ -2718,52 +2718,48 @@ impl<T: TriHashItem, S: Clone + BuildHasher, A: Allocator> TriHashMap<T, S, A> {
     }
 
     pub(super) fn remove_by_index(&mut self, remove_index: usize) -> Option<T> {
-        let value = self.items.remove(remove_index)?;
-
-        // Remove the value from the tables.
+        // For panic safety, look up all three table entries while `self.items`
+        // still holds the value, then remove from all three tables and items
+        // in sequence. hashbrown's `find_entry` is panic-safe under
+        // user-`Hash`/`Eq` panics (the table is not mutated until
+        // `OccupiedEntry::remove` is called), so a panic during the lookups
+        // leaves items and all three tables unmodified.
+        let item = self.items.get(remove_index)?;
+        let key1 = item.key1();
+        let key2 = item.key2();
+        let key3 = item.key3();
         let state = &self.tables.state;
-        let Ok(item1) =
-            self.tables.k1_to_item.find_entry(state, &value.key1(), |index| {
-                if index == remove_index {
-                    value.key1()
-                } else {
-                    self.items[index].key1()
-                }
-            })
+        let Ok(entry1) =
+            self.tables
+                .k1_to_item
+                .find_entry(state, &key1, |index| self.items[index].key1())
         else {
-            // The item was not found.
             panic!("remove_index {remove_index} not found in k1_to_item");
         };
-        let Ok(item2) =
-            self.tables.k2_to_item.find_entry(state, &value.key2(), |index| {
-                if index == remove_index {
-                    value.key2()
-                } else {
-                    self.items[index].key2()
-                }
-            })
+        let Ok(entry2) =
+            self.tables
+                .k2_to_item
+                .find_entry(state, &key2, |index| self.items[index].key2())
         else {
-            // The item was not found.
-            panic!("remove_index {remove_index} not found in k2_to_item")
+            panic!("remove_index {remove_index} not found in k2_to_item");
         };
-        let Ok(item3) =
-            self.tables.k3_to_item.find_entry(state, &value.key3(), |index| {
-                if index == remove_index {
-                    value.key3()
-                } else {
-                    self.items[index].key3()
-                }
-            })
+        let Ok(entry3) =
+            self.tables
+                .k3_to_item
+                .find_entry(state, &key3, |index| self.items[index].key3())
         else {
-            // The item was not found.
-            panic!("remove_index {remove_index} not found in k3_to_item")
+            panic!("remove_index {remove_index} not found in k3_to_item");
         };
-
-        item1.remove();
-        item2.remove();
-        item3.remove();
-
-        Some(value)
+        // Drop the keys so that `self.items` can be mutated below.
+        drop((key1, key2, key3));
+        entry1.remove();
+        entry2.remove();
+        entry3.remove();
+        Some(
+            self.items
+                .remove(remove_index)
+                .expect("items[remove_index] was Occupied above"),
+        )
     }
 }
 

--- a/crates/iddqd/tests/integration/bi_hash_map.rs
+++ b/crates/iddqd/tests/integration/bi_hash_map.rs
@@ -1067,3 +1067,82 @@ fn proptest_arbitrary_map(map: BiHashMap<TestItem, HashBuilder, Alloc>) {
     }
     assert_eq!(count, len);
 }
+
+#[cfg(feature = "default-hasher")]
+mod remove_panic_safety {
+    use super::*;
+    use crate::panic_safety::{
+        PanickyKey, arm_panic_after, disarm_panic, take_op_count,
+    };
+    use iddqd_test_utils::unwind::catch_panic;
+
+    #[derive(Clone, Debug)]
+    struct PanickyHashItem {
+        key1: u32,
+        key2: u32,
+    }
+
+    impl BiHashItem for PanickyHashItem {
+        type K1<'a> = PanickyKey;
+        type K2<'a> = PanickyKey;
+        fn key1(&self) -> Self::K1<'_> {
+            PanickyKey(self.key1)
+        }
+        fn key2(&self) -> Self::K2<'_> {
+            PanickyKey(self.key2)
+        }
+        bi_upcast!();
+    }
+
+    /// Run `remove1(&PanickyKey(8))` with the panic armed at the start
+    /// of the `target_lookup`-th `find_entry` inside `remove_by_index`
+    /// (1 = k1, 2 = k2).
+    fn run_remove1_panicking_at_lookup(target_lookup: u32) {
+        let mut map = BiHashMap::<PanickyHashItem>::new();
+        for i in 0..16u32 {
+            map.insert_unique(PanickyHashItem { key1: i, key2: 100 + i })
+                .unwrap();
+        }
+
+        let _ = take_op_count();
+        assert!(map.contains_key1(&PanickyKey(8)));
+        let probe_k1 = take_op_count();
+        assert!(probe_k1 > 0, "k1 lookup should make at least one key call");
+
+        // Successive phase costs in `remove1`: find_index k1, then find_entry
+        // k1, then find_entry k2. Sum the list of probes that must succeed
+        // before the find_entry we're trying to test.
+        let phase_costs = [
+            /* find_index k1 */ probe_k1,
+            /* find_entry k1 */ probe_k1,
+        ];
+        let arm_count: u32 = phase_costs[..target_lookup as usize].iter().sum();
+
+        arm_panic_after(arm_count);
+        let result = catch_panic(|| {
+            map.remove1(&PanickyKey(8));
+        });
+        disarm_panic();
+        let panic_ops = take_op_count();
+
+        assert!(result.is_none(), "expected the remove to panic");
+        assert_eq!(
+            panic_ops,
+            arm_count + 1,
+            "panic should fire on the (arm_count + 1)-th key-trait call",
+        );
+
+        map.validate(ValidateCompact::Compact)
+            .expect("map should remain consistent after a panicking remove");
+    }
+
+    #[test]
+    fn remove_panicking_in_k1_lookup_leaves_map_consistent() {
+        run_remove1_panicking_at_lookup(1);
+    }
+
+    #[test]
+    fn remove_panicking_in_k2_lookup_leaves_map_consistent() {
+        run_remove1_panicking_at_lookup(2);
+    }
+}

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -859,3 +859,59 @@ mod serde_tests {
         );
     }
 }
+
+#[cfg(feature = "default-hasher")]
+mod remove_panic_safety {
+    use super::*;
+    use crate::panic_safety::{
+        PanickyKey, arm_panic_after, disarm_panic, take_op_count,
+    };
+    use iddqd_test_utils::unwind::catch_panic;
+
+    #[derive(Clone, Debug)]
+    struct PanickyHashItem {
+        key: u32,
+    }
+
+    impl IdHashItem for PanickyHashItem {
+        type Key<'a> = PanickyKey;
+        fn key(&self) -> Self::Key<'_> {
+            PanickyKey(self.key)
+        }
+        id_upcast!();
+    }
+
+    #[test]
+    fn remove_panicking_in_user_hash_leaves_map_consistent() {
+        let mut map = IdHashMap::<PanickyHashItem>::new();
+        for i in 0..16u32 {
+            map.insert_unique(PanickyHashItem { key: i }).unwrap();
+        }
+
+        // Probe how many key-trait calls the lookup makes, so we can
+        // fire the panic on the call that follows the probe — i.e.
+        // inside `remove`'s own `find_entry` (which precedes any table
+        // mutation).
+        let _ = take_op_count();
+        assert!(map.contains_key(&PanickyKey(8)));
+        let probe_ops = take_op_count();
+        assert!(probe_ops > 0, "lookup should make at least one key call");
+
+        arm_panic_after(probe_ops);
+        let result = catch_panic(|| {
+            map.remove(&PanickyKey(8));
+        });
+        disarm_panic();
+        let panic_ops = take_op_count();
+
+        assert!(result.is_none(), "expected the remove to panic");
+        assert_eq!(
+            panic_ops,
+            probe_ops + 1,
+            "panic should fire on the (probe_ops + 1)-th key-trait call",
+        );
+
+        map.validate(ValidateCompact::Compact)
+            .expect("map should remain consistent after a panicking remove");
+    }
+}

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -1041,3 +1041,57 @@ fn proptest_arbitrary_map(map: IdOrdMap<TestItem>) {
     }
     assert_eq!(count, len);
 }
+
+mod remove_panic_safety {
+    use super::*;
+    use crate::panic_safety::{
+        PanickyKey, arm_panic_after, disarm_panic, take_op_count,
+    };
+
+    #[derive(Clone, Debug)]
+    struct PanickyOrdItem {
+        key: u32,
+    }
+
+    impl IdOrdItem for PanickyOrdItem {
+        type Key<'a> = PanickyKey;
+        fn key(&self) -> Self::Key<'_> {
+            PanickyKey(self.key)
+        }
+        id_upcast!();
+    }
+
+    #[test]
+    fn remove_panicking_in_user_ord_leaves_map_consistent() {
+        let mut map = IdOrdMap::<PanickyOrdItem>::new();
+        for i in 0..16u32 {
+            map.insert_unique(PanickyOrdItem { key: i }).unwrap();
+        }
+
+        // Probe how many `cmp` calls `find_index` performs for this
+        // tree shape, so we can fire the panic on the call that
+        // follows the probe, i.e. inside the B-tree lookup that
+        // precedes any tree mutation.
+        let _ = take_op_count();
+        assert!(map.contains_key(&PanickyKey(8)));
+        let find_ops = take_op_count();
+        assert!(find_ops > 0, "find_index should make at least one cmp call");
+
+        arm_panic_after(find_ops);
+        let result = catch_panic(|| {
+            map.remove(&PanickyKey(8));
+        });
+        disarm_panic();
+        let panic_ops = take_op_count();
+
+        assert!(result.is_none(), "expected the remove to panic");
+        assert_eq!(
+            panic_ops,
+            find_ops + 1,
+            "panic should fire on the (find_ops + 1)-th key-trait call",
+        );
+
+        map.validate(ValidateCompact::Compact, ValidateChaos::No)
+            .expect("map should remain consistent after a panicking remove");
+    }
+}

--- a/crates/iddqd/tests/integration/main.rs
+++ b/crates/iddqd/tests/integration/main.rs
@@ -2,6 +2,8 @@ mod bi_hash_map;
 mod id_hash_map;
 #[cfg(feature = "std")]
 mod id_ord_map;
+#[cfg(any(feature = "std", feature = "default-hasher"))]
+mod panic_safety;
 #[cfg(feature = "schemars08")]
 mod schemars_tests;
 #[cfg(all(

--- a/crates/iddqd/tests/integration/panic_safety.rs
+++ b/crates/iddqd/tests/integration/panic_safety.rs
@@ -28,9 +28,10 @@ use core::{
 };
 
 thread_local! {
-    /// Counts down on each `PanickyKey` trait-method call. When zero,
-    /// the next call panics. `u32::MAX` = disarmed.
-    static PANIC_COUNTDOWN: Cell<u32> = const { Cell::new(u32::MAX) };
+    /// Counts down on each `PanickyKey` trait-method call while `Some`.
+    /// When the count reaches zero, the next call panics. `None` means
+    /// disarmed; calls pass through without affecting the countdown.
+    static PANIC_COUNTDOWN: Cell<Option<u32>> = const { Cell::new(None) };
     /// Total number of `PanickyKey` trait-method calls observed; used
     /// by tests to probe how many calls a lookup path performs.
     static OP_COUNT: Cell<u32> = const { Cell::new(0) };
@@ -46,11 +47,11 @@ impl PanickyKey {
     fn observe_call(label: &'static str) {
         OP_COUNT.with(|c| c.set(c.get() + 1));
         PANIC_COUNTDOWN.with(|c| {
-            let n = c.get();
+            let Some(n) = c.get() else { return };
             if n == 0 {
                 panic!("PanickyKey::{label} panic triggered");
             }
-            c.set(n - 1);
+            c.set(Some(n - 1));
         });
     }
 }
@@ -90,11 +91,11 @@ pub(crate) fn take_op_count() -> u32 {
 /// Arms the countdown: the next `n` `PanickyKey` operations succeed,
 /// and the call after that panics.
 pub(crate) fn arm_panic_after(n: u32) {
-    PANIC_COUNTDOWN.with(|c| c.set(n));
+    PANIC_COUNTDOWN.with(|c| c.set(Some(n)));
 }
 
 /// Disarms the countdown so subsequent `PanickyKey` operations don't
 /// panic — call before any post-panic validation.
 pub(crate) fn disarm_panic() {
-    PANIC_COUNTDOWN.with(|c| c.set(u32::MAX));
+    PANIC_COUNTDOWN.with(|c| c.set(None));
 }

--- a/crates/iddqd/tests/integration/panic_safety.rs
+++ b/crates/iddqd/tests/integration/panic_safety.rs
@@ -1,0 +1,100 @@
+//! Shared scaffolding for panic safety tests.
+//!
+//! The map types invoke user-supplied `Hash`, `Eq`, and `Ord` impls on the key
+//! type as part of every find/insert/remove. If one of those impls panics
+//! partway through an operation, the items buffer and the external index tables
+//! must remain consistent, otherwise a later operation could observe a stale or
+//! out-of-bounds index.
+//!
+//! The panic safety tests use [`PanickyKey`] as the key type, and arm a
+//! countdown via [`arm_panic_after`]; the next [`PanickyKey`] operation after
+//! `n` successful ones panics. The usual shape is:
+//!
+//! 1. Fill the map with items.
+//! 2. Probe how many key-trait calls the lookup path makes, typically by
+//!    running a successful `contains_key` with [`take_op_count`].
+//! 3. Arm the countdown so the panic fires on the call that follows the
+//!    probe count (i.e. during the lookup that precedes the table mutation).
+//! 4. Catch the panic and validate the map.
+//!
+//! We rely on nextest's process-per-test model to ensure that
+//! [`PANIC_COUNTDOWN`] and [`OP_COUNT`] are not reused between tests running on
+//! the same thread.
+
+use core::{
+    cell::Cell,
+    cmp::Ordering,
+    hash::{Hash, Hasher},
+};
+
+thread_local! {
+    /// Counts down on each `PanickyKey` trait-method call. When zero,
+    /// the next call panics. `u32::MAX` = disarmed.
+    static PANIC_COUNTDOWN: Cell<u32> = const { Cell::new(u32::MAX) };
+    /// Total number of `PanickyKey` trait-method calls observed; used
+    /// by tests to probe how many calls a lookup path performs.
+    static OP_COUNT: Cell<u32> = const { Cell::new(0) };
+}
+
+/// A key type whose `Hash`/`Eq`/`Ord` impls share a panic countdown, so that
+/// tests can deterministically trigger a panic at a chosen point in any map
+/// operation.
+#[derive(Clone, Debug, Eq)]
+pub(crate) struct PanickyKey(pub u32);
+
+impl PanickyKey {
+    fn observe_call(label: &'static str) {
+        OP_COUNT.with(|c| c.set(c.get() + 1));
+        PANIC_COUNTDOWN.with(|c| {
+            let n = c.get();
+            if n == 0 {
+                panic!("PanickyKey::{label} panic triggered");
+            }
+            c.set(n - 1);
+        });
+    }
+}
+
+impl PartialEq for PanickyKey {
+    fn eq(&self, other: &Self) -> bool {
+        Self::observe_call("eq");
+        self.0 == other.0
+    }
+}
+
+impl PartialOrd for PanickyKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PanickyKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        Self::observe_call("cmp");
+        self.0.cmp(&other.0)
+    }
+}
+
+impl Hash for PanickyKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Self::observe_call("hash");
+        self.0.hash(state);
+    }
+}
+
+/// Returns the operation counter and resets it to zero.
+pub(crate) fn take_op_count() -> u32 {
+    OP_COUNT.with(|c| c.replace(0))
+}
+
+/// Arms the countdown: the next `n` `PanickyKey` operations succeed,
+/// and the call after that panics.
+pub(crate) fn arm_panic_after(n: u32) {
+    PANIC_COUNTDOWN.with(|c| c.set(n));
+}
+
+/// Disarms the countdown so subsequent `PanickyKey` operations don't
+/// panic — call before any post-panic validation.
+pub(crate) fn disarm_panic() {
+    PANIC_COUNTDOWN.with(|c| c.set(u32::MAX));
+}

--- a/crates/iddqd/tests/integration/tri_hash_map.rs
+++ b/crates/iddqd/tests/integration/tri_hash_map.rs
@@ -974,3 +974,103 @@ fn proptest_arbitrary_map(map: TriHashMap<TestItem, HashBuilder, Alloc>) {
     }
     assert_eq!(count, len);
 }
+
+#[cfg(feature = "default-hasher")]
+mod remove_panic_safety {
+    use super::*;
+    use crate::panic_safety::{
+        PanickyKey, arm_panic_after, disarm_panic, take_op_count,
+    };
+    use iddqd_test_utils::unwind::catch_panic;
+
+    #[derive(Clone, Debug)]
+    struct PanickyHashItem {
+        key1: u32,
+        key2: u32,
+        key3: u32,
+    }
+
+    impl TriHashItem for PanickyHashItem {
+        type K1<'a> = PanickyKey;
+        type K2<'a> = PanickyKey;
+        type K3<'a> = PanickyKey;
+        fn key1(&self) -> Self::K1<'_> {
+            PanickyKey(self.key1)
+        }
+        fn key2(&self) -> Self::K2<'_> {
+            PanickyKey(self.key2)
+        }
+        fn key3(&self) -> Self::K3<'_> {
+            PanickyKey(self.key3)
+        }
+        tri_upcast!();
+    }
+
+    /// Run `remove1(&PanickyKey(8))` with the panic armed at the start
+    /// of the `target_lookup`-th `find_entry` inside `remove_by_index`
+    /// (1 = k1, 2 = k2, 3 = k3).
+    fn run_remove1_panicking_at_lookup(target_lookup: u32) {
+        let mut map = TriHashMap::<PanickyHashItem>::new();
+        for i in 0..16u32 {
+            map.insert_unique(PanickyHashItem {
+                key1: i,
+                key2: 100 + i,
+                key3: 200 + i,
+            })
+            .unwrap();
+        }
+
+        let _ = take_op_count();
+        assert!(map.contains_key1(&PanickyKey(8)));
+        let probe_k1 = take_op_count();
+        assert!(probe_k1 > 0, "k1 lookup should make at least one key call");
+        assert!(map.contains_key2(&PanickyKey(108)));
+        let probe_k2 = take_op_count();
+        assert!(probe_k2 > 0, "k2 lookup should make at least one key call");
+
+        // The arm count is the sum of key operations that must succeed before
+        // the target find_entry. The phases preceding find_entry kN are
+        // find_index k1, find_entry k1, ..., find_entry k(N-1) — so for the
+        // largest target (N=3), we compute up to find_entry k2, then stop.
+        // find_entry k3's operations don't need to be considered, since we
+        // panic at the beginning of each set of operations.
+        let phase_costs = [
+            /* find_index k1 */ probe_k1,
+            /* find_entry k1 */ probe_k1,
+            /* find_entry k2 */ probe_k2,
+        ];
+        let arm_count: u32 = phase_costs[..target_lookup as usize].iter().sum();
+
+        arm_panic_after(arm_count);
+        let result = catch_panic(|| {
+            map.remove1(&PanickyKey(8));
+        });
+        disarm_panic();
+        let panic_ops = take_op_count();
+
+        assert!(result.is_none(), "expected the remove to panic");
+        assert_eq!(
+            panic_ops,
+            arm_count + 1,
+            "panic should fire on the (arm_count + 1)-th key-trait call",
+        );
+
+        map.validate(ValidateCompact::Compact)
+            .expect("map should remain consistent after a panicking remove");
+    }
+
+    #[test]
+    fn remove_panicking_in_k1_lookup_leaves_map_consistent() {
+        run_remove1_panicking_at_lookup(1);
+    }
+
+    #[test]
+    fn remove_panicking_in_k2_lookup_leaves_map_consistent() {
+        run_remove1_panicking_at_lookup(2);
+    }
+
+    #[test]
+    fn remove_panicking_in_k3_lookup_leaves_map_consistent() {
+        run_remove1_panicking_at_lookup(3);
+    }
+}


### PR DESCRIPTION
This is not a memory-safety violation, but it is a useful property that we can uphold without much work. Add tests, and then fix up the code to ensure that the internal indexes are consistent.

I've audited the other mutation code paths to ensure that they stay consistent during panics.

Also mention that nextest is required to run tests.
