### PR TITLE
[integration-tests] add proptests for panic safety

### DIFF
--- a/crates/iddqd/src/id_hash_map/imp.rs
+++ b/crates/iddqd/src/id_hash_map/imp.rs
@@ -949,22 +949,20 @@ impl<T: IdHashItem, S: Clone + BuildHasher, A: Allocator> IdHashMap<T, S, A> {
     /// ```
     #[doc(alias = "insert")]
     pub fn insert_overwrite(&mut self, value: T) -> Option<T> {
-        // Trying to write this function for maximal efficiency can get very
-        // tricky, requiring delicate handling of indexes. We follow a very
-        // simple approach instead:
+        // Go through the entry API so all user-`Hash`/`Eq` work happens before
+        // any table mutation. A panic in user code therefore leaves the map in
+        // its pre-call state.
         //
-        // 1. Remove items corresponding to the key that is already in the map.
-        // 2. Add the item to the map.
-
-        let duplicate = self.remove(&value.key());
-
-        if self.insert_unique(value).is_err() {
-            // We should never get here, because we just removed all the
-            // duplicates.
-            panic!("insert_unique failed after removing duplicates");
+        // We use `vacant.insert_entry` rather than `vacant.insert` to avoid a
+        // `RefMut`, whose `Drop` would (unnecessarily) re-hash the key *after*
+        // the mutation.
+        match self.entry(value.key()) {
+            Entry::Occupied(mut occupied) => Some(occupied.insert(value)),
+            Entry::Vacant(vacant) => {
+                vacant.insert_entry(value);
+                None
+            }
         }
-
-        duplicate
     }
 
     /// Inserts a value into the set, returning an error if any duplicates were

--- a/crates/iddqd/src/id_hash_map/imp.rs
+++ b/crates/iddqd/src/id_hash_map/imp.rs
@@ -949,13 +949,13 @@ impl<T: IdHashItem, S: Clone + BuildHasher, A: Allocator> IdHashMap<T, S, A> {
     /// ```
     #[doc(alias = "insert")]
     pub fn insert_overwrite(&mut self, value: T) -> Option<T> {
-        // Go through the entry API so all user-`Hash`/`Eq` work happens before
-        // any table mutation. A panic in user code therefore leaves the map in
-        // its pre-call state.
+        // Go through the entry API so all user code is called before any table
+        // mutation. A panic in user code therefore leaves the map in its
+        // pre-call state.
         //
-        // We use `vacant.insert_entry` rather than `vacant.insert` to avoid a
-        // `RefMut`, whose `Drop` would (unnecessarily) re-hash the key *after*
-        // the mutation.
+        // We use `vacant.insert_entry` rather than `vacant.insert` to avoid
+        // creating a `RefMut`, which would (unnecessarily) re-hash the key
+        // after the mutation when that `RefMut` is created.
         match self.entry(value.key()) {
             Entry::Occupied(mut occupied) => Some(occupied.insert(value)),
             Entry::Vacant(vacant) => {

--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -706,13 +706,13 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     /// ```
     #[doc(alias = "insert")]
     pub fn insert_overwrite(&mut self, value: T) -> Option<T> {
-        // Go through the entry API so all user-`Hash`/`Eq` work happens before
-        // any table mutation. A panic in user code therefore leaves the map in
-        // its pre-call state.
+        // Go through the entry API so all user code is called before any table
+        // mutation. A panic in user code therefore leaves the map in its
+        // pre-call state.
         //
-        // We use `vacant.insert_entry` rather than `vacant.insert` to avoid a
-        // `RefMut`, whose `Drop` would (unnecessarily) re-hash the key *after*
-        // the mutation.
+        // We use `vacant.insert_entry` rather than `vacant.insert` to avoid
+        // creating a `RefMut`, which would (unnecessarily) re-hash the key
+        // after the mutation when that `RefMut` is created.
         match self.entry(value.key()) {
             Entry::Occupied(mut occupied) => Some(occupied.insert(value)),
             Entry::Vacant(vacant) => {

--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -706,22 +706,20 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     /// ```
     #[doc(alias = "insert")]
     pub fn insert_overwrite(&mut self, value: T) -> Option<T> {
-        // Trying to write this function for maximal efficiency can get very
-        // tricky, requiring delicate handling of indexes. We follow a very
-        // simple approach instead:
+        // Go through the entry API so all user-`Hash`/`Eq` work happens before
+        // any table mutation. A panic in user code therefore leaves the map in
+        // its pre-call state.
         //
-        // 1. Remove the item corresponding to the key that is already in the map.
-        // 2. Add the item to the map.
-
-        let duplicate = self.remove(&value.key());
-
-        if self.insert_unique(value).is_err() {
-            // We should never get here, because we just removed all the
-            // duplicates.
-            panic!("insert_unique failed after removing duplicates");
+        // We use `vacant.insert_entry` rather than `vacant.insert` to avoid a
+        // `RefMut`, whose `Drop` would (unnecessarily) re-hash the key *after*
+        // the mutation.
+        match self.entry(value.key()) {
+            Entry::Occupied(mut occupied) => Some(occupied.insert(value)),
+            Entry::Vacant(vacant) => {
+                vacant.insert_entry(value);
+                None
+            }
         }
-
-        duplicate
     }
 
     /// Returns true if the map contains the given `key`.

--- a/crates/iddqd/tests/integration/bi_hash_map.rs
+++ b/crates/iddqd/tests/integration/bi_hash_map.rs
@@ -1069,80 +1069,187 @@ fn proptest_arbitrary_map(map: BiHashMap<TestItem, HashBuilder, Alloc>) {
 }
 
 #[cfg(feature = "default-hasher")]
-mod remove_panic_safety {
+#[derive(Clone, Debug)]
+struct PanickyHashItem {
+    key1: u32,
+    key2: u32,
+}
+
+#[cfg(feature = "default-hasher")]
+impl BiHashItem for PanickyHashItem {
+    type K1<'a> = crate::panic_safety::PanickyKey;
+    type K2<'a> = crate::panic_safety::PanickyKey;
+    fn key1(&self) -> Self::K1<'_> {
+        crate::panic_safety::PanickyKey(self.key1)
+    }
+    fn key2(&self) -> Self::K2<'_> {
+        crate::panic_safety::PanickyKey(self.key2)
+    }
+    bi_upcast!();
+}
+
+#[cfg(feature = "default-hasher")]
+mod proptest_panic_safety {
     use super::*;
     use crate::panic_safety::{
-        PanickyKey, arm_panic_after, disarm_panic, take_op_count,
+        PanicSafety, PanickyKey, PanickyOp, assert_panic_fired_as_expected,
+        assert_post_op_invariants, run_armed, sorted_keys,
     };
-    use iddqd_test_utils::unwind::catch_panic;
 
-    #[derive(Clone, Debug)]
-    struct PanickyHashItem {
-        key1: u32,
-        key2: u32,
+    // Keys are kept in a small range so hits and misses both happen
+    // frequently against a 16-ish-element map.
+    #[derive(Debug, Arbitrary)]
+    enum PanickyAction {
+        #[weight(4)]
+        InsertUnique(#[strategy(0..32_u32)] u32, #[strategy(0..32_u32)] u32),
+        #[weight(3)]
+        InsertOverwrite(#[strategy(0..32_u32)] u32, #[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        Remove1(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        Remove2(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        Get1(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        Get2(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        ContainsKey1(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        ContainsKey2(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        RetainModulo(
+            #[strategy(0..3_u32)] u32,
+            #[strategy(1..4_u32)] u32,
+            bool,
+        ),
+        #[weight(2)]
+        Extend(
+            #[strategy(prop::collection::vec(
+                (0..32_u32, 0..32_u32), 0..8,
+            ))]
+            Vec<(u32, u32)>,
+        ),
+        Clear,
     }
 
-    impl BiHashItem for PanickyHashItem {
-        type K1<'a> = PanickyKey;
-        type K2<'a> = PanickyKey;
-        fn key1(&self) -> Self::K1<'_> {
-            PanickyKey(self.key1)
+    impl PanickyAction {
+        /// Classify panic safety for this action.
+        ///
+        /// * `BiHashMap::insert_overwrite` runs
+        ///   `remove1; remove2; insert_unique;` as sequential commits,
+        ///   so a mid-sequence panic can leave the map in a different
+        ///   (but still valid) state.
+        /// * `RetainModulo` loops over per-step atomic mutations.
+        /// * `Extend` calls `HashTable::reserve` up front, which on a
+        ///   tombstone-heavy map drops into hashbrown's
+        ///   `rehash_in_place` — documented as not panic-safe under a
+        ///   user `Hash` panic, so the proptest skips arming for it.
+        fn panic_safety(&self) -> PanicSafety {
+            match self {
+                PanickyAction::InsertUnique(_, _) => PanicSafety::Atomic,
+                PanickyAction::InsertOverwrite(_, _) => PanicSafety::StepAtomic,
+                PanickyAction::Remove1(_)
+                | PanickyAction::Remove2(_)
+                | PanickyAction::Get1(_)
+                | PanickyAction::Get2(_)
+                | PanickyAction::ContainsKey1(_)
+                | PanickyAction::ContainsKey2(_) => PanicSafety::Atomic,
+                PanickyAction::RetainModulo(_, _, _) => PanicSafety::StepAtomic,
+                PanickyAction::Extend(_) => PanicSafety::MayCorruptOnPanic,
+                PanickyAction::Clear => PanicSafety::Atomic,
+            }
         }
-        fn key2(&self) -> Self::K2<'_> {
-            PanickyKey(self.key2)
+
+        fn run(self, map: &mut BiHashMap<PanickyHashItem>) {
+            match self {
+                PanickyAction::InsertUnique(key1, key2) => {
+                    let _ = map.insert_unique(PanickyHashItem { key1, key2 });
+                }
+                PanickyAction::InsertOverwrite(key1, key2) => {
+                    let _ =
+                        map.insert_overwrite(PanickyHashItem { key1, key2 });
+                }
+                PanickyAction::Remove1(key1) => {
+                    let _ = map.remove1(&PanickyKey(key1));
+                }
+                PanickyAction::Remove2(key2) => {
+                    let _ = map.remove2(&PanickyKey(key2));
+                }
+                PanickyAction::Get1(key1) => {
+                    let _ = map.get1(&PanickyKey(key1));
+                }
+                PanickyAction::Get2(key2) => {
+                    let _ = map.get2(&PanickyKey(key2));
+                }
+                PanickyAction::ContainsKey1(key1) => {
+                    let _ = map.contains_key1(&PanickyKey(key1));
+                }
+                PanickyAction::ContainsKey2(key2) => {
+                    let _ = map.contains_key2(&PanickyKey(key2));
+                }
+                PanickyAction::RetainModulo(rem, modulo, keep) => {
+                    map.retain(|item| {
+                        let matches = item.key1 % modulo == rem;
+                        if keep { matches } else { !matches }
+                    });
+                }
+                PanickyAction::Extend(pairs) => {
+                    map.extend(
+                        pairs
+                            .into_iter()
+                            .map(|(key1, key2)| PanickyHashItem { key1, key2 }),
+                    );
+                }
+                PanickyAction::Clear => map.clear(),
+            }
         }
-        bi_upcast!();
     }
 
-    /// Run `remove1(&PanickyKey(8))` with the panic armed at the start
-    /// of the `target_lookup`-th `find_entry` inside `remove_by_index`
-    /// (1 = k1, 2 = k2).
-    fn run_remove1_panicking_at_lookup(target_lookup: u32) {
+    #[proptest(cases = 16)]
+    fn proptest_panic_ops(
+        #[strategy(prop::collection::vec(
+            any::<PanickyOp<PanickyAction>>(), 0..512,
+        ))]
+        ops: Vec<PanickyOp<PanickyAction>>,
+    ) {
         let mut map = BiHashMap::<PanickyHashItem>::new();
-        for i in 0..16u32 {
-            map.insert_unique(PanickyHashItem { key1: i, key2: 100 + i })
-                .unwrap();
+
+        for (i, op) in ops.into_iter().enumerate() {
+            let action = op.action;
+            let action_label = format!("{action:?}");
+            let panic_safety = action.panic_safety();
+            let armed = match panic_safety {
+                PanicSafety::MayCorruptOnPanic => None,
+                PanicSafety::Atomic | PanicSafety::StepAtomic => op.armed,
+            };
+
+            let pre_state = sorted_keys(&map, |item| (item.key1, item.key2));
+            let (panicked, ops) = run_armed(armed, || action.run(&mut map));
+            assert_panic_fired_as_expected(&action_label, armed, panicked, ops);
+
+            // `NonCompact` since step-atomic panics can leave compactness in an
+            // indeterminate state.
+            map.validate(ValidateCompact::NonCompact).unwrap_or_else(|err| {
+                panic!(
+                    "map invalid after op {i} ({action_label}, \
+                     armed: {armed:?}, panicked: {panicked}): {err}"
+                )
+            });
+
+            let post_state = sorted_keys(&map, |item| (item.key1, item.key2));
+            assert_post_op_invariants(
+                i,
+                &action_label,
+                armed,
+                panicked,
+                panic_safety,
+                &pre_state,
+                &post_state,
+                |&(k1, k2)| {
+                    map.contains_key1(&PanickyKey(k1))
+                        && map.contains_key2(&PanickyKey(k2))
+                },
+            );
         }
-
-        let _ = take_op_count();
-        assert!(map.contains_key1(&PanickyKey(8)));
-        let probe_k1 = take_op_count();
-        assert!(probe_k1 > 0, "k1 lookup should make at least one key call");
-
-        // Successive phase costs in `remove1`: find_index k1, then find_entry
-        // k1, then find_entry k2. Sum the list of probes that must succeed
-        // before the find_entry we're trying to test.
-        let phase_costs = [
-            /* find_index k1 */ probe_k1,
-            /* find_entry k1 */ probe_k1,
-        ];
-        let arm_count: u32 = phase_costs[..target_lookup as usize].iter().sum();
-
-        arm_panic_after(arm_count);
-        let result = catch_panic(|| {
-            map.remove1(&PanickyKey(8));
-        });
-        disarm_panic();
-        let panic_ops = take_op_count();
-
-        assert!(result.is_none(), "expected the remove to panic");
-        assert_eq!(
-            panic_ops,
-            arm_count + 1,
-            "panic should fire on the (arm_count + 1)-th key-trait call",
-        );
-
-        map.validate(ValidateCompact::Compact)
-            .expect("map should remain consistent after a panicking remove");
-    }
-
-    #[test]
-    fn remove_panicking_in_k1_lookup_leaves_map_consistent() {
-        run_remove1_panicking_at_lookup(1);
-    }
-
-    #[test]
-    fn remove_panicking_in_k2_lookup_leaves_map_consistent() {
-        run_remove1_panicking_at_lookup(2);
     }
 }

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -861,57 +861,148 @@ mod serde_tests {
 }
 
 #[cfg(feature = "default-hasher")]
-mod remove_panic_safety {
+#[derive(Clone, Debug)]
+struct PanickyHashItem {
+    key: u32,
+}
+
+#[cfg(feature = "default-hasher")]
+impl IdHashItem for PanickyHashItem {
+    type Key<'a> = crate::panic_safety::PanickyKey;
+    fn key(&self) -> Self::Key<'_> {
+        crate::panic_safety::PanickyKey(self.key)
+    }
+    id_upcast!();
+}
+
+#[cfg(feature = "default-hasher")]
+mod proptest_panic_safety {
     use super::*;
     use crate::panic_safety::{
-        PanickyKey, arm_panic_after, disarm_panic, take_op_count,
+        PanicSafety, PanickyKey, PanickyOp, assert_panic_fired_as_expected,
+        assert_post_op_invariants, run_armed, sorted_keys,
     };
-    use iddqd_test_utils::unwind::catch_panic;
 
-    #[derive(Clone, Debug)]
-    struct PanickyHashItem {
-        key: u32,
+    // Keys are kept in a small range so collisions, hits, and misses
+    // all happen frequently against a 16-ish-element map.
+    #[derive(Debug, Arbitrary)]
+    enum PanickyAction {
+        #[weight(4)]
+        InsertUnique(#[strategy(0..32_u32)] u32),
+        #[weight(3)]
+        InsertOverwrite(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        Remove(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        Get(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        ContainsKey(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        RetainModulo(
+            #[strategy(0..3_u32)] u32,
+            #[strategy(1..4_u32)] u32,
+            bool,
+        ),
+        #[weight(2)]
+        Extend(#[strategy(prop::collection::vec(0..32_u32, 0..8))] Vec<u32>),
+        Clear,
     }
 
-    impl IdHashItem for PanickyHashItem {
-        type Key<'a> = PanickyKey;
-        fn key(&self) -> Self::Key<'_> {
-            PanickyKey(self.key)
+    impl PanickyAction {
+        /// Classify panic safety for this action.
+        ///
+        /// * `RetainModulo` loops over per-step atomic mutations.
+        /// * `Extend` calls `HashTable::reserve` up front, which on a
+        ///   tombstone-heavy map drops into hashbrown's `rehash_in_place`.
+        ///   Hashbrown documetns `rehash_in_place` as not panic-safe.
+        fn panic_safety(&self) -> PanicSafety {
+            match self {
+                PanickyAction::InsertUnique(_)
+                | PanickyAction::InsertOverwrite(_)
+                | PanickyAction::Remove(_)
+                | PanickyAction::Get(_)
+                | PanickyAction::ContainsKey(_) => PanicSafety::Atomic,
+                PanickyAction::RetainModulo(_, _, _) => PanicSafety::StepAtomic,
+                PanickyAction::Extend(_) => PanicSafety::MayCorruptOnPanic,
+                PanickyAction::Clear => PanicSafety::Atomic,
+            }
         }
-        id_upcast!();
+
+        fn run(self, map: &mut IdHashMap<PanickyHashItem>) {
+            match self {
+                PanickyAction::InsertUnique(key) => {
+                    let _ = map.insert_unique(PanickyHashItem { key });
+                }
+                PanickyAction::InsertOverwrite(key) => {
+                    let _ = map.insert_overwrite(PanickyHashItem { key });
+                }
+                PanickyAction::Remove(key) => {
+                    let _ = map.remove(&PanickyKey(key));
+                }
+                PanickyAction::Get(key) => {
+                    let _ = map.get(&PanickyKey(key));
+                }
+                PanickyAction::ContainsKey(key) => {
+                    let _ = map.contains_key(&PanickyKey(key));
+                }
+                PanickyAction::RetainModulo(rem, modulo, keep) => {
+                    map.retain(|item| {
+                        let matches = item.key % modulo == rem;
+                        if keep { matches } else { !matches }
+                    });
+                }
+                PanickyAction::Extend(keys) => {
+                    map.extend(
+                        keys.into_iter().map(|key| PanickyHashItem { key }),
+                    );
+                }
+                PanickyAction::Clear => map.clear(),
+            }
+        }
     }
 
-    #[test]
-    fn remove_panicking_in_user_hash_leaves_map_consistent() {
+    #[proptest(cases = 16)]
+    fn proptest_panic_ops(
+        #[strategy(prop::collection::vec(
+            any::<PanickyOp<PanickyAction>>(), 0..512,
+        ))]
+        ops: Vec<PanickyOp<PanickyAction>>,
+    ) {
         let mut map = IdHashMap::<PanickyHashItem>::new();
-        for i in 0..16u32 {
-            map.insert_unique(PanickyHashItem { key: i }).unwrap();
+
+        for (i, op) in ops.into_iter().enumerate() {
+            let action = op.action;
+            let action_label = format!("{action:?}");
+            let panic_safety = action.panic_safety();
+            let armed = match panic_safety {
+                PanicSafety::MayCorruptOnPanic => None,
+                PanicSafety::Atomic | PanicSafety::StepAtomic => op.armed,
+            };
+
+            let pre_state = sorted_keys(&map, |item| item.key);
+            let (panicked, ops) = run_armed(armed, || action.run(&mut map));
+            assert_panic_fired_as_expected(&action_label, armed, panicked, ops);
+
+            // `NonCompact` since step-atomic panics leave compactness
+            // in an indeterminate state.
+            map.validate(ValidateCompact::NonCompact).unwrap_or_else(|err| {
+                panic!(
+                    "map invalid after op {i} ({action_label}, \
+                     armed: {armed:?}, panicked: {panicked}): {err}"
+                )
+            });
+
+            let post_state = sorted_keys(&map, |item| item.key);
+            assert_post_op_invariants(
+                i,
+                &action_label,
+                armed,
+                panicked,
+                panic_safety,
+                &pre_state,
+                &post_state,
+                |&k| map.contains_key(&PanickyKey(k)),
+            );
         }
-
-        // Probe how many key-trait calls the lookup makes, so we can
-        // fire the panic on the call that follows the probe — i.e.
-        // inside `remove`'s own `find_entry` (which precedes any table
-        // mutation).
-        let _ = take_op_count();
-        assert!(map.contains_key(&PanickyKey(8)));
-        let probe_ops = take_op_count();
-        assert!(probe_ops > 0, "lookup should make at least one key call");
-
-        arm_panic_after(probe_ops);
-        let result = catch_panic(|| {
-            map.remove(&PanickyKey(8));
-        });
-        disarm_panic();
-        let panic_ops = take_op_count();
-
-        assert!(result.is_none(), "expected the remove to panic");
-        assert_eq!(
-            panic_ops,
-            probe_ops + 1,
-            "panic should fire on the (probe_ops + 1)-th key-trait call",
-        );
-
-        map.validate(ValidateCompact::Compact)
-            .expect("map should remain consistent after a panicking remove");
     }
 }

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -914,7 +914,7 @@ mod proptest_panic_safety {
         /// * `RetainModulo` loops over per-step atomic mutations.
         /// * `Extend` calls `HashTable::reserve` up front, which on a
         ///   tombstone-heavy map drops into hashbrown's `rehash_in_place`.
-        ///   Hashbrown documetns `rehash_in_place` as not panic-safe.
+        ///   Hashbrown documents `rehash_in_place` as not panic-safe.
         fn panic_safety(&self) -> PanicSafety {
             match self {
                 PanickyAction::InsertUnique(_)

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -1042,56 +1042,157 @@ fn proptest_arbitrary_map(map: IdOrdMap<TestItem>) {
     assert_eq!(count, len);
 }
 
-mod remove_panic_safety {
+#[derive(Clone, Debug)]
+struct PanickyOrdItem {
+    key: u32,
+}
+
+impl IdOrdItem for PanickyOrdItem {
+    type Key<'a> = crate::panic_safety::PanickyKey;
+    fn key(&self) -> Self::Key<'_> {
+        crate::panic_safety::PanickyKey(self.key)
+    }
+    id_upcast!();
+}
+
+mod proptest_panic_safety {
     use super::*;
     use crate::panic_safety::{
-        PanickyKey, arm_panic_after, disarm_panic, take_op_count,
+        PanicSafety, PanickyKey, PanickyOp, assert_panic_fired_as_expected,
+        assert_post_op_invariants, run_armed, sorted_keys,
     };
 
-    #[derive(Clone, Debug)]
-    struct PanickyOrdItem {
-        key: u32,
+    // Keys are kept in a small range so hits and misses both happen
+    // frequently against a 16-ish-element map.
+    #[derive(Debug, Arbitrary)]
+    enum PanickyAction {
+        #[weight(4)]
+        InsertUnique(#[strategy(0..32_u32)] u32),
+        #[weight(3)]
+        InsertOverwrite(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        Remove(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        Get(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        ContainsKey(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        PopFirst,
+        #[weight(1)]
+        PopLast,
+        #[weight(2)]
+        RetainModulo(
+            #[strategy(0..3_u32)] u32,
+            #[strategy(1..4_u32)] u32,
+            bool,
+        ),
+        #[weight(2)]
+        Extend(#[strategy(prop::collection::vec(0..32_u32, 0..8))] Vec<u32>),
+        Clear,
     }
 
-    impl IdOrdItem for PanickyOrdItem {
-        type Key<'a> = PanickyKey;
-        fn key(&self) -> Self::Key<'_> {
-            PanickyKey(self.key)
+    impl PanickyAction {
+        /// Classify panic safety for this action.
+        ///
+        /// `Extend` and `RetainModulo` loop over per-step atomic
+        /// mutations.
+        fn panic_safety(&self) -> PanicSafety {
+            match self {
+                PanickyAction::InsertUnique(_)
+                | PanickyAction::InsertOverwrite(_)
+                | PanickyAction::Remove(_)
+                | PanickyAction::Get(_)
+                | PanickyAction::ContainsKey(_)
+                | PanickyAction::PopFirst
+                | PanickyAction::PopLast => PanicSafety::Atomic,
+                PanickyAction::RetainModulo(_, _, _)
+                | PanickyAction::Extend(_) => PanicSafety::StepAtomic,
+                PanickyAction::Clear => PanicSafety::Atomic,
+            }
         }
-        id_upcast!();
+
+        fn run(self, map: &mut IdOrdMap<PanickyOrdItem>) {
+            match self {
+                PanickyAction::InsertUnique(key) => {
+                    let _ = map.insert_unique(PanickyOrdItem { key });
+                }
+                PanickyAction::InsertOverwrite(key) => {
+                    let _ = map.insert_overwrite(PanickyOrdItem { key });
+                }
+                PanickyAction::Remove(key) => {
+                    let _ = map.remove(&PanickyKey(key));
+                }
+                PanickyAction::Get(key) => {
+                    let _ = map.get(&PanickyKey(key));
+                }
+                PanickyAction::ContainsKey(key) => {
+                    let _ = map.contains_key(&PanickyKey(key));
+                }
+                PanickyAction::PopFirst => {
+                    let _ = map.pop_first();
+                }
+                PanickyAction::PopLast => {
+                    let _ = map.pop_last();
+                }
+                PanickyAction::RetainModulo(rem, modulo, keep) => {
+                    map.retain(|item| {
+                        let matches = item.key % modulo == rem;
+                        if keep { matches } else { !matches }
+                    });
+                }
+                PanickyAction::Extend(keys) => {
+                    map.extend(
+                        keys.into_iter().map(|key| PanickyOrdItem { key }),
+                    );
+                }
+                PanickyAction::Clear => map.clear(),
+            }
+        }
     }
 
-    #[test]
-    fn remove_panicking_in_user_ord_leaves_map_consistent() {
+    #[proptest(cases = 16)]
+    fn proptest_panic_ops(
+        #[strategy(prop::collection::vec(
+            any::<PanickyOp<PanickyAction>>(), 0..512,
+        ))]
+        ops: Vec<PanickyOp<PanickyAction>>,
+    ) {
         let mut map = IdOrdMap::<PanickyOrdItem>::new();
-        for i in 0..16u32 {
-            map.insert_unique(PanickyOrdItem { key: i }).unwrap();
+
+        for (i, op) in ops.into_iter().enumerate() {
+            let action = op.action;
+            let action_label = format!("{action:?}");
+            let panic_safety = action.panic_safety();
+            let armed = match panic_safety {
+                PanicSafety::MayCorruptOnPanic => None,
+                PanicSafety::Atomic | PanicSafety::StepAtomic => op.armed,
+            };
+
+            let pre_state = sorted_keys(&map, |item| item.key);
+            let (panicked, ops) = run_armed(armed, || action.run(&mut map));
+            assert_panic_fired_as_expected(&action_label, armed, panicked, ops);
+
+            // `NonCompact` since step-atomic panics leave compactness
+            // in an indeterminate state.
+            map.validate(ValidateCompact::NonCompact, ValidateChaos::No)
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "map invalid after op {i} ({action_label}, \
+                         armed: {armed:?}, panicked: {panicked}): {err}"
+                    )
+                });
+
+            let post_state = sorted_keys(&map, |item| item.key);
+            assert_post_op_invariants(
+                i,
+                &action_label,
+                armed,
+                panicked,
+                panic_safety,
+                &pre_state,
+                &post_state,
+                |&k| map.contains_key(&PanickyKey(k)),
+            );
         }
-
-        // Probe how many `cmp` calls `find_index` performs for this
-        // tree shape, so we can fire the panic on the call that
-        // follows the probe, i.e. inside the B-tree lookup that
-        // precedes any tree mutation.
-        let _ = take_op_count();
-        assert!(map.contains_key(&PanickyKey(8)));
-        let find_ops = take_op_count();
-        assert!(find_ops > 0, "find_index should make at least one cmp call");
-
-        arm_panic_after(find_ops);
-        let result = catch_panic(|| {
-            map.remove(&PanickyKey(8));
-        });
-        disarm_panic();
-        let panic_ops = take_op_count();
-
-        assert!(result.is_none(), "expected the remove to panic");
-        assert_eq!(
-            panic_ops,
-            find_ops + 1,
-            "panic should fire on the (find_ops + 1)-th key-trait call",
-        );
-
-        map.validate(ValidateCompact::Compact, ValidateChaos::No)
-            .expect("map should remain consistent after a panicking remove");
     }
 }

--- a/crates/iddqd/tests/integration/panic_safety.rs
+++ b/crates/iddqd/tests/integration/panic_safety.rs
@@ -1,45 +1,30 @@
 //! Shared scaffolding for panic safety tests.
 //!
-//! The map types invoke user-supplied `Hash`, `Eq`, and `Ord` impls on the key
-//! type as part of every find/insert/remove. If one of those impls panics
-//! partway through an operation, the items buffer and the external index tables
-//! must remain consistent, otherwise a later operation could observe a stale or
-//! out-of-bounds index.
+//! [`PanickyKey`] is a key whose `Hash`/`Eq`/`Ord` impls share a thread-local
+//! panic countdown. The call after `n` successful ones panics. Each proptest
+//! drives a random sequence of [`PanickyOp`]s, and after every step asserts:
 //!
-//! The panic safety tests use [`PanickyKey`] as the key type, and arm a
-//! countdown via [`arm_panic_after`]; the next [`PanickyKey`] operation after
-//! `n` successful ones panics. The usual shape is:
-//!
-//! 1. Fill the map with items.
-//! 2. Probe how many key-trait calls the lookup path makes, typically by
-//!    running a successful `contains_key` with [`take_op_count`].
-//! 3. Arm the countdown so the panic fires on the call that follows the
-//!    probe count (i.e. during the lookup that precedes the table mutation).
-//! 4. Catch the panic and validate the map.
-//!
-//! We rely on nextest's process-per-test model to ensure that
-//! [`PANIC_COUNTDOWN`] and [`OP_COUNT`] are not reused between tests running on
-//! the same thread.
+//! * `validate()`
+//! * a `contains_key` round-trip on every surviving item
+//! * (for atomic ops that panicked) that the post-op state equals the pre-op
+//!   snapshot.
 
 use core::{
     cell::Cell,
     cmp::Ordering,
+    fmt,
     hash::{Hash, Hasher},
 };
+use iddqd_test_utils::unwind::catch_panic;
+use proptest::prelude::*;
 
 thread_local! {
-    /// Counts down on each `PanickyKey` trait-method call while `Some`.
-    /// When the count reaches zero, the next call panics. `None` means
-    /// disarmed; calls pass through without affecting the countdown.
     static PANIC_COUNTDOWN: Cell<Option<u32>> = const { Cell::new(None) };
-    /// Total number of `PanickyKey` trait-method calls observed; used
-    /// by tests to probe how many calls a lookup path performs.
     static OP_COUNT: Cell<u32> = const { Cell::new(0) };
 }
 
-/// A key type whose `Hash`/`Eq`/`Ord` impls share a panic countdown, so that
-/// tests can deterministically trigger a panic at a chosen point in any map
-/// operation.
+/// A key whose `Hash`/`Eq`/`Ord` impls share a panic countdown, so
+/// tests can deterministically trigger a panic at a chosen point.
 #[derive(Clone, Debug, Eq)]
 pub(crate) struct PanickyKey(pub u32);
 
@@ -83,19 +68,148 @@ impl Hash for PanickyKey {
     }
 }
 
-/// Returns the operation counter and resets it to zero.
-pub(crate) fn take_op_count() -> u32 {
+fn take_op_count() -> u32 {
     OP_COUNT.with(|c| c.replace(0))
 }
 
-/// Arms the countdown: the next `n` `PanickyKey` operations succeed,
-/// and the call after that panics.
-pub(crate) fn arm_panic_after(n: u32) {
+fn arm_panic_after(n: u32) {
     PANIC_COUNTDOWN.with(|c| c.set(Some(n)));
 }
 
-/// Disarms the countdown so subsequent `PanickyKey` operations don't
-/// panic — call before any post-panic validation.
-pub(crate) fn disarm_panic() {
+fn disarm_panic() {
     PANIC_COUNTDOWN.with(|c| c.set(None));
+}
+
+#[derive(Debug)]
+pub(crate) struct PanickyOp<A> {
+    pub(crate) action: A,
+    pub(crate) armed: Option<u32>,
+}
+
+impl<A> Arbitrary for PanickyOp<A>
+where
+    A: Arbitrary + fmt::Debug + 'static,
+{
+    type Parameters = A::Parameters;
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(args: A::Parameters) -> Self::Strategy {
+        // Bias towards `None` so the map fills up, otherwise panicking ops
+        // would dominate and leave the map empty.
+        let armed = prop_oneof![
+            7 => Just(None),
+            3 => (0..16_u32).prop_map(Some),
+        ];
+        (any_with::<A>(args), armed)
+            .prop_map(|(action, armed)| PanickyOp { action, armed })
+            .boxed()
+    }
+}
+
+/// Run `f` with the panic countdown set, then unconditionally disarm
+/// so a leftover countdown can't trip later code. Returns
+/// `(panicked, ops)` where `ops` is the count of `PanickyKey`
+/// trait-method calls made during `f`.
+pub(crate) fn run_armed(armed: Option<u32>, f: impl FnOnce()) -> (bool, u32) {
+    let _ = take_op_count();
+    if let Some(n) = armed {
+        arm_panic_after(n);
+    }
+    let result = catch_panic(f);
+    disarm_panic();
+    let ops = take_op_count();
+    (result.is_none(), ops)
+}
+
+/// Asserts that the panic-countdown infrastructure fired (or didn't)
+/// exactly as the arming would predict.
+///
+/// With `armed = Some(n)`, the panic should fire on the `(n+1)`-th key
+/// call, so `panicked` implies `ops == n + 1`, and `!panicked` implies
+/// the action made at most `n` key calls. With `armed = None`, no
+/// panic should escape.
+pub(crate) fn assert_panic_fired_as_expected(
+    op_label: &dyn fmt::Display,
+    armed: Option<u32>,
+    panicked: bool,
+    ops: u32,
+) {
+    match (armed, panicked) {
+        (Some(n), true) => assert_eq!(
+            ops,
+            n + 1,
+            "op {op_label} (armed: {n}) panicked on key call {ops}, \
+             expected call {}",
+            n + 1,
+        ),
+        (Some(n), false) => assert!(
+            ops <= n,
+            "op {op_label} (armed: {n}) made {ops} key call(s) but \
+             did not panic — the panic countdown failed to fire",
+        ),
+        (None, true) => panic!(
+            "op {op_label} panicked unexpectedly with no armed \
+             countdown (ops: {ops})",
+        ),
+        (None, false) => {}
+    }
+}
+
+/// `K` is a single key for `IdHashMap`/`IdOrdMap` or a tuple of all
+/// keys for `BiHashMap`/`TriHashMap`.
+pub(crate) fn sorted_keys<I, K, F>(items: I, key_of: F) -> Vec<K>
+where
+    I: IntoIterator,
+    K: Ord,
+    F: Fn(I::Item) -> K,
+{
+    let mut keys: Vec<K> = items.into_iter().map(key_of).collect();
+    keys.sort_unstable();
+    keys
+}
+
+/// Classifies how an action should behave under a user-trait panic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PanicSafety {
+    /// A panic must leave the map in its pre-call state.
+    Atomic,
+    /// Composed of atomic sub-steps; a panic may leave the map in a different
+    /// but still-valid state.
+    StepAtomic,
+    /// May corrupt the underlying table. Callers must skip arming a panic for
+    /// this op.
+    MayCorruptOnPanic,
+}
+
+/// Asserts that every surviving item is findable, and (for atomic ops
+/// that panicked) that the post-op state equals the pre-op snapshot.
+///
+/// `contains_keys` should check *all* of an item's keys for multi-key
+/// maps.
+pub(crate) fn assert_post_op_invariants<K>(
+    step: usize,
+    op_label: &dyn fmt::Display,
+    armed: Option<u32>,
+    panicked: bool,
+    panic_safety: PanicSafety,
+    pre_state: &[K],
+    post_state: &[K],
+    contains_keys: impl Fn(&K) -> bool,
+) where
+    K: PartialEq + fmt::Debug,
+{
+    for key in post_state {
+        assert!(
+            contains_keys(key),
+            "item with key {key:?} not findable after op {step} \
+             ({op_label}, armed: {armed:?}, panicked: {panicked})",
+        );
+    }
+    if panicked && panic_safety == PanicSafety::Atomic {
+        assert_eq!(
+            post_state, pre_state,
+            "atomic op {op_label} (armed: {armed:?}) panicked at \
+             step {step} but the map state changed",
+        );
+    }
 }

--- a/crates/iddqd/tests/integration/panic_safety.rs
+++ b/crates/iddqd/tests/integration/panic_safety.rs
@@ -178,6 +178,7 @@ pub(crate) enum PanicSafety {
     StepAtomic,
     /// May corrupt the underlying table. Callers must skip arming a panic for
     /// this op.
+    #[allow(dead_code)] // unused without `default-hasher`
     MayCorruptOnPanic,
 }
 
@@ -186,6 +187,7 @@ pub(crate) enum PanicSafety {
 ///
 /// `contains_keys` should check *all* of an item's keys for multi-key
 /// maps.
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn assert_post_op_invariants<K>(
     step: usize,
     op_label: &dyn fmt::Display,

--- a/crates/iddqd/tests/integration/tri_hash_map.rs
+++ b/crates/iddqd/tests/integration/tri_hash_map.rs
@@ -976,101 +976,211 @@ fn proptest_arbitrary_map(map: TriHashMap<TestItem, HashBuilder, Alloc>) {
 }
 
 #[cfg(feature = "default-hasher")]
-mod remove_panic_safety {
+#[derive(Clone, Debug)]
+struct PanickyHashItem {
+    key1: u32,
+    key2: u32,
+    key3: u32,
+}
+
+#[cfg(feature = "default-hasher")]
+impl TriHashItem for PanickyHashItem {
+    type K1<'a> = crate::panic_safety::PanickyKey;
+    type K2<'a> = crate::panic_safety::PanickyKey;
+    type K3<'a> = crate::panic_safety::PanickyKey;
+    fn key1(&self) -> Self::K1<'_> {
+        crate::panic_safety::PanickyKey(self.key1)
+    }
+    fn key2(&self) -> Self::K2<'_> {
+        crate::panic_safety::PanickyKey(self.key2)
+    }
+    fn key3(&self) -> Self::K3<'_> {
+        crate::panic_safety::PanickyKey(self.key3)
+    }
+    tri_upcast!();
+}
+
+#[cfg(feature = "default-hasher")]
+mod proptest_panic_safety {
     use super::*;
     use crate::panic_safety::{
-        PanickyKey, arm_panic_after, disarm_panic, take_op_count,
+        PanicSafety, PanickyKey, PanickyOp, assert_panic_fired_as_expected,
+        assert_post_op_invariants, run_armed, sorted_keys,
     };
-    use iddqd_test_utils::unwind::catch_panic;
 
-    #[derive(Clone, Debug)]
-    struct PanickyHashItem {
-        key1: u32,
-        key2: u32,
-        key3: u32,
+    // Keys are kept in a small range so hits and misses both happen
+    // frequently against a 16-ish-element map.
+    #[derive(Debug, Arbitrary)]
+    enum PanickyAction {
+        #[weight(4)]
+        InsertUnique(
+            #[strategy(0..32_u32)] u32,
+            #[strategy(0..32_u32)] u32,
+            #[strategy(0..32_u32)] u32,
+        ),
+        #[weight(3)]
+        InsertOverwrite(
+            #[strategy(0..32_u32)] u32,
+            #[strategy(0..32_u32)] u32,
+            #[strategy(0..32_u32)] u32,
+        ),
+        #[weight(2)]
+        Remove1(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        Remove2(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        Remove3(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        Get1(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        Get2(#[strategy(0..32_u32)] u32),
+        #[weight(1)]
+        Get3(#[strategy(0..32_u32)] u32),
+        #[weight(2)]
+        RetainModulo(
+            #[strategy(0..3_u32)] u32,
+            #[strategy(1..4_u32)] u32,
+            bool,
+        ),
+        #[weight(2)]
+        Extend(
+            #[strategy(prop::collection::vec(
+                (0..32_u32, 0..32_u32, 0..32_u32), 0..8,
+            ))]
+            Vec<(u32, u32, u32)>,
+        ),
+        Clear,
     }
 
-    impl TriHashItem for PanickyHashItem {
-        type K1<'a> = PanickyKey;
-        type K2<'a> = PanickyKey;
-        type K3<'a> = PanickyKey;
-        fn key1(&self) -> Self::K1<'_> {
-            PanickyKey(self.key1)
+    impl PanickyAction {
+        /// Classify panic safety for this action.
+        ///
+        /// * `TriHashMap::insert_overwrite` runs
+        ///   `remove1; remove2; remove3; insert_unique;` as sequential
+        ///   commits, so a mid-sequence panic can leave the map in a
+        ///   different (but still valid) state.
+        /// * `RetainModulo` loops over per-step atomic mutations.
+        /// * `Extend` calls `HashTable::reserve` up front, which on a
+        ///   tombstone-heavy map drops into hashbrown's
+        ///   `rehash_in_place` — documented as not panic-safe under a
+        ///   user `Hash` panic, so the proptest skips arming for it.
+        fn panic_safety(&self) -> PanicSafety {
+            match self {
+                PanickyAction::InsertUnique(_, _, _) => PanicSafety::Atomic,
+                PanickyAction::InsertOverwrite(_, _, _) => {
+                    PanicSafety::StepAtomic
+                }
+                PanickyAction::Remove1(_)
+                | PanickyAction::Remove2(_)
+                | PanickyAction::Remove3(_)
+                | PanickyAction::Get1(_)
+                | PanickyAction::Get2(_)
+                | PanickyAction::Get3(_) => PanicSafety::Atomic,
+                PanickyAction::RetainModulo(_, _, _) => PanicSafety::StepAtomic,
+                PanickyAction::Extend(_) => PanicSafety::MayCorruptOnPanic,
+                PanickyAction::Clear => PanicSafety::Atomic,
+            }
         }
-        fn key2(&self) -> Self::K2<'_> {
-            PanickyKey(self.key2)
+
+        fn run(self, map: &mut TriHashMap<PanickyHashItem>) {
+            match self {
+                PanickyAction::InsertUnique(key1, key2, key3) => {
+                    let _ =
+                        map.insert_unique(PanickyHashItem { key1, key2, key3 });
+                }
+                PanickyAction::InsertOverwrite(key1, key2, key3) => {
+                    let _ = map.insert_overwrite(PanickyHashItem {
+                        key1,
+                        key2,
+                        key3,
+                    });
+                }
+                PanickyAction::Remove1(key1) => {
+                    let _ = map.remove1(&PanickyKey(key1));
+                }
+                PanickyAction::Remove2(key2) => {
+                    let _ = map.remove2(&PanickyKey(key2));
+                }
+                PanickyAction::Remove3(key3) => {
+                    let _ = map.remove3(&PanickyKey(key3));
+                }
+                PanickyAction::Get1(key1) => {
+                    let _ = map.get1(&PanickyKey(key1));
+                }
+                PanickyAction::Get2(key2) => {
+                    let _ = map.get2(&PanickyKey(key2));
+                }
+                PanickyAction::Get3(key3) => {
+                    let _ = map.get3(&PanickyKey(key3));
+                }
+                PanickyAction::RetainModulo(rem, modulo, keep) => {
+                    map.retain(|item| {
+                        let matches = item.key1 % modulo == rem;
+                        if keep { matches } else { !matches }
+                    });
+                }
+                PanickyAction::Extend(triples) => {
+                    map.extend(triples.into_iter().map(
+                        |(key1, key2, key3)| PanickyHashItem {
+                            key1,
+                            key2,
+                            key3,
+                        },
+                    ));
+                }
+                PanickyAction::Clear => map.clear(),
+            }
         }
-        fn key3(&self) -> Self::K3<'_> {
-            PanickyKey(self.key3)
-        }
-        tri_upcast!();
     }
 
-    /// Run `remove1(&PanickyKey(8))` with the panic armed at the start
-    /// of the `target_lookup`-th `find_entry` inside `remove_by_index`
-    /// (1 = k1, 2 = k2, 3 = k3).
-    fn run_remove1_panicking_at_lookup(target_lookup: u32) {
+    #[proptest(cases = 16)]
+    fn proptest_panic_ops(
+        #[strategy(prop::collection::vec(
+            any::<PanickyOp<PanickyAction>>(), 0..512,
+        ))]
+        ops: Vec<PanickyOp<PanickyAction>>,
+    ) {
         let mut map = TriHashMap::<PanickyHashItem>::new();
-        for i in 0..16u32 {
-            map.insert_unique(PanickyHashItem {
-                key1: i,
-                key2: 100 + i,
-                key3: 200 + i,
-            })
-            .unwrap();
+
+        for (i, op) in ops.into_iter().enumerate() {
+            let action = op.action;
+            let action_label = format!("{action:?}");
+            let panic_safety = action.panic_safety();
+            let armed = match panic_safety {
+                PanicSafety::MayCorruptOnPanic => None,
+                PanicSafety::Atomic | PanicSafety::StepAtomic => op.armed,
+            };
+
+            let pre_state =
+                sorted_keys(&map, |item| (item.key1, item.key2, item.key3));
+            let (panicked, ops) = run_armed(armed, || action.run(&mut map));
+            assert_panic_fired_as_expected(&action_label, armed, panicked, ops);
+
+            // `NonCompact` since step-atomic panics leave compactness
+            // in an indeterminate state.
+            map.validate(ValidateCompact::NonCompact).unwrap_or_else(|err| {
+                panic!(
+                    "map invalid after op {i} ({action_label}, \
+                     armed: {armed:?}, panicked: {panicked}): {err}"
+                )
+            });
+
+            let post_state =
+                sorted_keys(&map, |item| (item.key1, item.key2, item.key3));
+            assert_post_op_invariants(
+                i,
+                &action_label,
+                armed,
+                panicked,
+                panic_safety,
+                &pre_state,
+                &post_state,
+                |&(k1, k2, k3)| {
+                    map.contains_key1(&PanickyKey(k1))
+                        && map.contains_key2(&PanickyKey(k2))
+                        && map.contains_key3(&PanickyKey(k3))
+                },
+            );
         }
-
-        let _ = take_op_count();
-        assert!(map.contains_key1(&PanickyKey(8)));
-        let probe_k1 = take_op_count();
-        assert!(probe_k1 > 0, "k1 lookup should make at least one key call");
-        assert!(map.contains_key2(&PanickyKey(108)));
-        let probe_k2 = take_op_count();
-        assert!(probe_k2 > 0, "k2 lookup should make at least one key call");
-
-        // The arm count is the sum of key operations that must succeed before
-        // the target find_entry. The phases preceding find_entry kN are
-        // find_index k1, find_entry k1, ..., find_entry k(N-1) — so for the
-        // largest target (N=3), we compute up to find_entry k2, then stop.
-        // find_entry k3's operations don't need to be considered, since we
-        // panic at the beginning of each set of operations.
-        let phase_costs = [
-            /* find_index k1 */ probe_k1,
-            /* find_entry k1 */ probe_k1,
-            /* find_entry k2 */ probe_k2,
-        ];
-        let arm_count: u32 = phase_costs[..target_lookup as usize].iter().sum();
-
-        arm_panic_after(arm_count);
-        let result = catch_panic(|| {
-            map.remove1(&PanickyKey(8));
-        });
-        disarm_panic();
-        let panic_ops = take_op_count();
-
-        assert!(result.is_none(), "expected the remove to panic");
-        assert_eq!(
-            panic_ops,
-            arm_count + 1,
-            "panic should fire on the (arm_count + 1)-th key-trait call",
-        );
-
-        map.validate(ValidateCompact::Compact)
-            .expect("map should remain consistent after a panicking remove");
-    }
-
-    #[test]
-    fn remove_panicking_in_k1_lookup_leaves_map_consistent() {
-        run_remove1_panicking_at_lookup(1);
-    }
-
-    #[test]
-    fn remove_panicking_in_k2_lookup_leaves_map_consistent() {
-        run_remove1_panicking_at_lookup(2);
-    }
-
-    #[test]
-    fn remove_panicking_in_k3_lookup_leaves_map_consistent() {
-        run_remove1_panicking_at_lookup(3);
     }
 }


### PR DESCRIPTION
Extend the existing example-based tests into a set of proptests. This found an issue in insert_overwrite that can be worked around for the single-key maps.
