### PR TITLE
update cargo-sync-rdme nightly to 2026-04-30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install nightly toolchain for cargo-sync-rdme
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-08-31
+          toolchain: nightly-2026-04-30
       - name: Regenerate readmes
         run: just generate-readmes
       - name: Check for differences

--- a/Justfile
+++ b/Justfile
@@ -19,7 +19,7 @@ rustdoc *args:
 
 # Generate README.md files using `cargo-sync-rdme`.
 generate-readmes:
-    cargo sync-rdme --toolchain nightly-2025-08-31 --workspace --all-features
+    cargo sync-rdme --toolchain nightly-2026-04-30 --workspace --all-features
 
 # Run cargo release in CI.
 ci-cargo-release:


### PR DESCRIPTION
Required for cargo-sync-rdme 0.5.0.
