### PR TITLE
disallow retain from stashing away items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # 1.85 is the MSRV
-        rust-version: ["1.85", "stable"]
+        rust-version: ["stable"]
         partition: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
       fail-fast: false
     env:
@@ -72,7 +71,40 @@ jobs:
         run: just powerset --partition ${{ matrix.partition }}/10 nextest run
       - name: Doctests
         run: just powerset --partition ${{ matrix.partition }}/10 test --doc
-        
+
+  build-and-test-msrv:
+    name: Build and test (MSRV)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        # 1.85 is the MSRV
+        rust-version: ["1.85"]
+        partition: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+      fail-fast: false
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust-version }}
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: partition-${{ matrix.partition }}-msrv
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@just
+      - uses: taiki-e/install-action@nextest
+      - name: Build
+        run: just powerset --partition ${{ matrix.partition }}/10 build
+      # We don't run UI tests on the MSRV since compiler output varies by
+      # version.
+      - name: Run tests (excluding UI tests)
+        run: just powerset --partition ${{ matrix.partition }}/10 nextest run -E 'not binary_id(iddqd::ui)'
+      - name: Doctests
+        run: just powerset --partition ${{ matrix.partition }}/10 test --doc
+
+
   build-no-std:
     name: Build on no-std
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +382,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "test-strategy",
+ "trybuild",
 ]
 
 [[package]]
@@ -416,6 +429,16 @@ dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
  "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -763,7 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "indexmap",
+ "indexmap 1.9.3",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -845,6 +868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_tokenstream"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +935,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +951,15 @@ dependencies = [
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -956,6 +1003,60 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "trybuild"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
 ]
 
 [[package]]
@@ -1206,6 +1307,18 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.223"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a505d71960adde88e293da5cb5eda57093379f64e61cf77bf0e6a63af07a7bac"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -825,18 +825,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.223"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f57cbd357666aa7b3ac84a90b4ea328f1d4ddb6772b430caa5d9e1309bb9e9"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.223"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d428d07faf17e306e699ec1e91996e5a165ba5d6bce5b5155173e91a8a01a56"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -869,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.6"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -1017,14 +1017,14 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.1"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1035,7 +1035,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -1046,9 +1046,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "trybuild"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
 dependencies = [
  "glob",
  "serde",
@@ -1307,12 +1307,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = "1.0.223"
 serde_core = "1.0.223"
 serde_json = "1.0.145"
 test-strategy = "0.4.3"
-trybuild = "1.0.115"
+trybuild = "1.0.116"
 typify = "0.4.2"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde = "1.0.223"
 serde_core = "1.0.223"
 serde_json = "1.0.145"
 test-strategy = "0.4.3"
+trybuild = "1.0.115"
 typify = "0.4.2"
 
 [profile.dev]

--- a/crates/iddqd/Cargo.toml
+++ b/crates/iddqd/Cargo.toml
@@ -40,6 +40,7 @@ iddqd-test-utils.workspace = true
 proptest.workspace = true
 serde.workspace = true
 test-strategy.workspace = true
+trybuild.workspace = true
 
 [features]
 allocator-api2 = ["iddqd-test-utils/allocator-api2"]

--- a/crates/iddqd/src/bi_hash_map/imp.rs
+++ b/crates/iddqd/src/bi_hash_map/imp.rs
@@ -1926,7 +1926,7 @@ impl<T: BiHashItem, S: Clone + BuildHasher, A: Allocator> BiHashMap<T, S, A> {
     /// ```
     pub fn retain<'a, F>(&'a mut self, mut f: F)
     where
-        F: FnMut(RefMut<'a, T, S>) -> bool,
+        F: for<'b> FnMut(RefMut<'b, T, S>) -> bool,
     {
         let hash_state = self.tables.state.clone();
         let (_, mut dormant_items) = DormantMutRef::new(&mut self.items);

--- a/crates/iddqd/src/id_hash_map/imp.rs
+++ b/crates/iddqd/src/id_hash_map/imp.rs
@@ -1306,7 +1306,7 @@ impl<T: IdHashItem, S: Clone + BuildHasher, A: Allocator> IdHashMap<T, S, A> {
     /// ```
     pub fn retain<'a, F>(&'a mut self, mut f: F)
     where
-        F: FnMut(RefMut<'a, T, S>) -> bool,
+        F: for<'b> FnMut(RefMut<'b, T, S>) -> bool,
     {
         let hash_state = self.tables.state.clone();
         let (_, mut dormant_items) = DormantMutRef::new(&mut self.items);

--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -1307,7 +1307,7 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     /// ```
     pub fn retain<'a, F>(&'a mut self, mut f: F)
     where
-        F: FnMut(RefMut<'a, T>) -> bool,
+        F: for<'b> FnMut(RefMut<'b, T>) -> bool,
         T::Key<'a>: Hash,
     {
         let hash_state = self.tables.state().clone();

--- a/crates/iddqd/src/tri_hash_map/imp.rs
+++ b/crates/iddqd/src/tri_hash_map/imp.rs
@@ -2584,7 +2584,7 @@ impl<T: TriHashItem, S: Clone + BuildHasher, A: Allocator> TriHashMap<T, S, A> {
     /// ```
     pub fn retain<'a, F>(&'a mut self, mut f: F)
     where
-        F: FnMut(RefMut<'a, T, S>) -> bool,
+        F: for<'b> FnMut(RefMut<'b, T, S>) -> bool,
     {
         let hash_state = self.tables.state.clone();
         let (_, mut dormant_items) = DormantMutRef::new(&mut self.items);

--- a/crates/iddqd/tests/integration/bi_hash_map.rs
+++ b/crates/iddqd/tests/integration/bi_hash_map.rs
@@ -11,7 +11,10 @@ use iddqd_test_utils::{
     },
 };
 use proptest::prelude::*;
-use std::{borrow::Cow, path::Path};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 use test_strategy::{Arbitrary, proptest};
 
 #[derive(Clone, Debug)]
@@ -908,6 +911,36 @@ fn borrowed_item() {
             iddqd_test_utils::serde_json::from_str(&map_string).unwrap();
         assert_eq!(map, deserialized);
     }
+}
+
+#[test]
+fn borrowed_item_retain_non_static() {
+    let foo_key = String::from("foo");
+    let bar_key = String::from("bar");
+    let foo_bytes = b"foo".to_vec();
+    let bar_bytes = b"bar".to_vec();
+    let foo_path = PathBuf::from("foo");
+    let bar_path = PathBuf::from("bar");
+
+    let mut map = BiHashMap::<BorrowedItem<'_>, HashBuilder, Alloc>::default();
+    map.insert_unique(BorrowedItem {
+        key1: foo_key.as_str(),
+        key2: Cow::Borrowed(foo_bytes.as_slice()),
+        key3: foo_path.as_path(),
+    })
+    .unwrap();
+    map.insert_unique(BorrowedItem {
+        key1: bar_key.as_str(),
+        key2: Cow::Borrowed(bar_bytes.as_slice()),
+        key3: bar_path.as_path(),
+    })
+    .unwrap();
+
+    map.retain(|item| item.key1 == foo_key.as_str());
+
+    assert_eq!(map.len(), 1);
+    assert!(map.get1(foo_key.as_str()).is_some());
+    assert!(map.get1(bar_key.as_str()).is_none());
 }
 
 #[test]

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -11,7 +11,10 @@ use iddqd_test_utils::{
     },
 };
 use proptest::prelude::*;
-use std::{borrow::Cow, path::Path};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 use test_strategy::{Arbitrary, proptest};
 
 #[derive(Clone, Debug)]
@@ -617,6 +620,36 @@ fn borrowed_item() {
             iddqd_test_utils::serde_json::from_str(&map_string).unwrap();
         assert_eq!(map, deserialized);
     }
+}
+
+#[test]
+fn borrowed_item_retain_non_static() {
+    let foo_key = String::from("foo");
+    let bar_key = String::from("bar");
+    let foo_bytes = b"foo".to_vec();
+    let bar_bytes = b"bar".to_vec();
+    let foo_path = PathBuf::from("foo");
+    let bar_path = PathBuf::from("bar");
+
+    let mut map = IdHashMap::<BorrowedItem<'_>, HashBuilder, Alloc>::default();
+    map.insert_unique(BorrowedItem {
+        key1: foo_key.as_str(),
+        key2: Cow::Borrowed(foo_bytes.as_slice()),
+        key3: foo_path.as_path(),
+    })
+    .unwrap();
+    map.insert_unique(BorrowedItem {
+        key1: bar_key.as_str(),
+        key2: Cow::Borrowed(bar_bytes.as_slice()),
+        key3: bar_path.as_path(),
+    })
+    .unwrap();
+
+    map.retain(|item| item.key1 == foo_key.as_str());
+
+    assert_eq!(map.len(), 1);
+    assert!(map.get(foo_key.as_str()).is_some());
+    assert!(map.get(bar_key.as_str()).is_none());
 }
 
 #[test]

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -13,7 +13,10 @@ use iddqd_test_utils::{
     unwind::catch_panic,
 };
 use proptest::prelude::*;
-use std::{borrow::Cow, path::Path};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 use test_strategy::{Arbitrary, proptest};
 
 #[test]
@@ -968,6 +971,36 @@ fn borrowed_item() {
     }
 
     entry_api_tests(&mut map);
+}
+
+#[test]
+fn borrowed_item_retain_non_static() {
+    let foo_key = String::from("foo");
+    let bar_key = String::from("bar");
+    let foo_bytes = b"foo".to_vec();
+    let bar_bytes = b"bar".to_vec();
+    let foo_path = PathBuf::from("foo");
+    let bar_path = PathBuf::from("bar");
+
+    let mut map = IdOrdMap::<BorrowedItem<'_>>::default();
+    map.insert_unique(BorrowedItem {
+        key1: foo_key.as_str(),
+        key2: Cow::Borrowed(foo_bytes.as_slice()),
+        key3: foo_path.as_path(),
+    })
+    .unwrap();
+    map.insert_unique(BorrowedItem {
+        key1: bar_key.as_str(),
+        key2: Cow::Borrowed(bar_bytes.as_slice()),
+        key3: bar_path.as_path(),
+    })
+    .unwrap();
+
+    map.retain(|item| item.key1 == foo_key.as_str());
+
+    assert_eq!(map.len(), 1);
+    assert!(map.get(foo_key.as_str()).is_some());
+    assert!(map.get(bar_key.as_str()).is_none());
 }
 
 mod macro_tests {

--- a/crates/iddqd/tests/integration/tri_hash_map.rs
+++ b/crates/iddqd/tests/integration/tri_hash_map.rs
@@ -12,7 +12,10 @@ use iddqd_test_utils::{
     },
 };
 use proptest::prelude::*;
-use std::{borrow::Cow, path::Path};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 use test_strategy::{Arbitrary, proptest};
 
 #[derive(Clone, Debug)]
@@ -760,6 +763,36 @@ fn borrowed_item() {
             iddqd_test_utils::serde_json::from_str(&map_string).unwrap();
         assert_eq!(map, deserialized);
     }
+}
+
+#[test]
+fn borrowed_item_retain_non_static() {
+    let foo_key = String::from("foo");
+    let bar_key = String::from("bar");
+    let foo_bytes = b"foo".to_vec();
+    let bar_bytes = b"bar".to_vec();
+    let foo_path = PathBuf::from("foo");
+    let bar_path = PathBuf::from("bar");
+
+    let mut map = TriHashMap::<BorrowedItem<'_>, HashBuilder, Alloc>::default();
+    map.insert_unique(BorrowedItem {
+        key1: foo_key.as_str(),
+        key2: Cow::Borrowed(foo_bytes.as_slice()),
+        key3: foo_path.as_path(),
+    })
+    .unwrap();
+    map.insert_unique(BorrowedItem {
+        key1: bar_key.as_str(),
+        key2: Cow::Borrowed(bar_bytes.as_slice()),
+        key3: bar_path.as_path(),
+    })
+    .unwrap();
+
+    map.retain(|item| item.key1 == foo_key.as_str());
+
+    assert_eq!(map.len(), 1);
+    assert!(map.get1(foo_key.as_str()).is_some());
+    assert!(map.get1(bar_key.as_str()).is_none());
 }
 
 #[test]

--- a/crates/iddqd/tests/ui.rs
+++ b/crates/iddqd/tests/ui.rs
@@ -1,15 +1,8 @@
 //! UI tests.
 
+#[cfg(all(feature = "std", feature = "default-hasher"))]
 #[test]
 fn ui() {
-    #[cfg(not(all(feature = "std", feature = "default-hasher")))]
-    {
-        return;
-    }
-
-    #[cfg(all(feature = "std", feature = "default-hasher"))]
-    {
-        let t = trybuild::TestCases::new();
-        t.compile_fail("tests/ui/invalid/*.rs");
-    }
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/invalid/*.rs");
 }

--- a/crates/iddqd/tests/ui.rs
+++ b/crates/iddqd/tests/ui.rs
@@ -1,0 +1,15 @@
+//! UI tests.
+
+#[test]
+fn ui() {
+    #[cfg(not(all(feature = "std", feature = "default-hasher")))]
+    {
+        return;
+    }
+
+    #[cfg(all(feature = "std", feature = "default-hasher"))]
+    {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("tests/ui/invalid/*.rs");
+    }
+}

--- a/crates/iddqd/tests/ui/invalid/bi_hash_retain_stash.rs
+++ b/crates/iddqd/tests/ui/invalid/bi_hash_retain_stash.rs
@@ -1,0 +1,35 @@
+use iddqd::{BiHashItem, BiHashMap, bi_upcast};
+
+#[derive(Debug)]
+struct Item {
+    id: u32,
+    key2: u32,
+}
+
+impl BiHashItem for Item {
+    type K1<'a> = u32;
+    type K2<'a> = u32;
+
+    fn key1(&self) -> Self::K1<'_> {
+        self.id
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        self.key2
+    }
+
+    bi_upcast!();
+}
+
+fn main() {
+    let mut map = BiHashMap::<Item>::new();
+    map.insert_unique(Item { id: 0, key2: 10 }).unwrap();
+
+    let mut stashed = Vec::new();
+    map.retain(|item| {
+        stashed.push(item);
+        false
+    });
+
+    stashed[0].id = 1;
+}

--- a/crates/iddqd/tests/ui/invalid/bi_hash_retain_stash.stderr
+++ b/crates/iddqd/tests/ui/invalid/bi_hash_retain_stash.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/invalid/bi_hash_retain_stash.rs:30:9
+   |
+28 |     let mut stashed = Vec::new();
+   |         ----------- `stashed` declared here, outside of the closure body
+29 |     map.retain(|item| {
+   |                 ---- `item` is a reference that is only valid in the closure body
+30 |         stashed.push(item);
+   |         ^^^^^^^^^^^^^^^^^^ `item` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<iddqd::bi_hash_map::RefMut<'_, Item>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/crates/iddqd/tests/ui/invalid/id_hash_retain_stash.rs
+++ b/crates/iddqd/tests/ui/invalid/id_hash_retain_stash.rs
@@ -1,0 +1,29 @@
+use iddqd::{IdHashItem, IdHashMap, id_upcast};
+
+#[derive(Debug)]
+struct Item {
+    id: u32,
+}
+
+impl IdHashItem for Item {
+    type Key<'a> = u32;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.id
+    }
+
+    id_upcast!();
+}
+
+fn main() {
+    let mut map = IdHashMap::<Item>::new();
+    map.insert_unique(Item { id: 0 }).unwrap();
+
+    let mut stashed = Vec::new();
+    map.retain(|item| {
+        stashed.push(item);
+        false
+    });
+
+    stashed[0].id = 1;
+}

--- a/crates/iddqd/tests/ui/invalid/id_hash_retain_stash.stderr
+++ b/crates/iddqd/tests/ui/invalid/id_hash_retain_stash.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/invalid/id_hash_retain_stash.rs:24:9
+   |
+22 |     let mut stashed = Vec::new();
+   |         ----------- `stashed` declared here, outside of the closure body
+23 |     map.retain(|item| {
+   |                 ---- `item` is a reference that is only valid in the closure body
+24 |         stashed.push(item);
+   |         ^^^^^^^^^^^^^^^^^^ `item` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<iddqd::id_hash_map::RefMut<'_, Item>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/crates/iddqd/tests/ui/invalid/id_ord_retain_stash.rs
+++ b/crates/iddqd/tests/ui/invalid/id_ord_retain_stash.rs
@@ -1,0 +1,29 @@
+use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
+
+#[derive(Debug)]
+struct Item {
+    id: u32,
+}
+
+impl IdOrdItem for Item {
+    type Key<'a> = u32;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.id
+    }
+
+    id_upcast!();
+}
+
+fn main() {
+    let mut map = IdOrdMap::<Item>::new();
+    map.insert_unique(Item { id: 0 }).unwrap();
+
+    let mut stashed = Vec::new();
+    map.retain(|item| {
+        stashed.push(item);
+        false
+    });
+
+    stashed[0].id = 1;
+}

--- a/crates/iddqd/tests/ui/invalid/id_ord_retain_stash.stderr
+++ b/crates/iddqd/tests/ui/invalid/id_ord_retain_stash.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/invalid/id_ord_retain_stash.rs:24:9
+   |
+22 |     let mut stashed = Vec::new();
+   |         ----------- `stashed` declared here, outside of the closure body
+23 |     map.retain(|item| {
+   |                 ---- `item` is a reference that is only valid in the closure body
+24 |         stashed.push(item);
+   |         ^^^^^^^^^^^^^^^^^^ `item` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<iddqd::id_ord_map::RefMut<'_, Item>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/crates/iddqd/tests/ui/invalid/tri_hash_retain_stash.rs
+++ b/crates/iddqd/tests/ui/invalid/tri_hash_retain_stash.rs
@@ -1,0 +1,46 @@
+use iddqd::{TriHashItem, TriHashMap, tri_upcast};
+
+#[derive(Debug)]
+struct Item {
+    id: u32,
+    key2: u32,
+    key3: u32,
+}
+
+impl TriHashItem for Item {
+    type K1<'a> = u32;
+    type K2<'a> = u32;
+    type K3<'a> = u32;
+
+    fn key1(&self) -> Self::K1<'_> {
+        self.id
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        self.key2
+    }
+
+    fn key3(&self) -> Self::K3<'_> {
+        self.key3
+    }
+
+    tri_upcast!();
+}
+
+fn main() {
+    let mut map = TriHashMap::<Item>::new();
+    map.insert_unique(Item {
+        id: 0,
+        key2: 10,
+        key3: 20,
+    })
+    .unwrap();
+
+    let mut stashed = Vec::new();
+    map.retain(|item| {
+        stashed.push(item);
+        false
+    });
+
+    stashed[0].id = 1;
+}

--- a/crates/iddqd/tests/ui/invalid/tri_hash_retain_stash.stderr
+++ b/crates/iddqd/tests/ui/invalid/tri_hash_retain_stash.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/invalid/tri_hash_retain_stash.rs:41:9
+   |
+39 |     let mut stashed = Vec::new();
+   |         ----------- `stashed` declared here, outside of the closure body
+40 |     map.retain(|item| {
+   |                 ---- `item` is a reference that is only valid in the closure body
+41 |         stashed.push(item);
+   |         ^^^^^^^^^^^^^^^^^^ `item` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<iddqd::tri_hash_map::RefMut<'_, Item>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance


### PR DESCRIPTION
The `retain` signature was wrong -- we could previously stash away items and then return `false`, causing a use-after-free. Restrict the lifetime, and add UI tests to ensure that it always fails.

This is technically a breaking change but we're treating it as a soundness bugfix.
