### PR TITLE
more resiliency to buggy user code in IdOrdMap

### DIFF
--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -359,7 +359,7 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     /// Does nothing if capacity is already sufficient.
     ///
     /// Note: This only reserves capacity in the item storage. The internal
-    /// [`BTreeSet`] used for key-to-item mapping does not support capacity
+    /// `BTreeMap` used for key-to-item mapping does not support capacity
     /// reservation.
     ///
     /// # Panics
@@ -402,7 +402,7 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     /// and possibly leaving some space in accordance with the resize policy.
     ///
     /// Note: This only shrinks the item storage capacity. The internal
-    /// [`BTreeSet`] used for key-to-item mapping does not support capacity
+    /// `BTreeMap` used for key-to-item mapping does not support capacity
     /// control.
     ///
     /// # Examples
@@ -446,7 +446,7 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     /// If the current capacity is less than the lower limit, this is a no-op.
     ///
     /// Note: This only shrinks the item storage capacity. The internal
-    /// [`BTreeSet`] used for key-to-item mapping does not support capacity
+    /// `BTreeMap` used for key-to-item mapping does not support capacity
     /// control.
     ///
     /// # Examples

--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -1445,10 +1445,12 @@ impl<T: IdOrdItem> IdOrdMap<T> {
         let grow_handle = self.items.assert_can_grow();
         let next_index = grow_handle.next_index();
         let key = value.key();
-        self.tables
-            .key_to_item
-            .insert(next_index, &key, |index| grow_handle[index].key());
+        let insert =
+            self.tables.key_to_item.prepare_insert(next_index, &key, |index| {
+                grow_handle[index].key()
+            });
         drop(key);
+        insert.insert();
         grow_handle.insert(value);
 
         Ok(next_index)
@@ -1459,19 +1461,30 @@ impl<T: IdOrdItem> IdOrdMap<T> {
         remove_index: ItemIndex,
     ) -> Option<T> {
         // For panic safety, read the key while self.items still holds the slot,
-        // then remove from the B-tree *before* mutating self.items.
+        // then locate the B-tree entry before mutating self.items.
         //
-        // `BTreeSet::remove` is panic-safe under user-`Ord` panics, since
-        // comparator panics during the internal binary search abort the
-        // operation without modifying the tree. (This is not a documented
-        // guarantee, but really the only reasonable way to implement a
-        // panic-safe B-tree map.) This means that a panic at this point leaves
-        // both items and the B-tree unmodified. `items.remove` afterwards
-        // cannot panic.
+        // `BTreeMap::entry` is panic-safe under user-`Ord` panics, since
+        // comparator panics during the internal binary search abort the lookup
+        // without modifying the tree. (This is not a documented guarantee, but
+        // really the only reasonable way to implement a panic-safe B-tree map.)
+        // This means that a panic at this point leaves both items and the
+        // B-tree unmodified. After the entry has been located, `drop(key)` can
+        // run user code, so it must happen before the B-tree or item slot is
+        // mutated.
+        //
+        // If BTreeMap::entry returns normally but misses due to already-broken
+        // tree ordering, the prepared remove falls back to exact-index cleanup
+        // before this item slot can be reused.
         let key = self.items.get(remove_index)?.key();
-        self.tables
-            .key_to_item
-            .remove(remove_index, key, |index| self.items[index].key());
+        let remove = self.tables.key_to_item.prepare_remove(
+            remove_index,
+            &key,
+            |index| self.items[index].key(),
+        );
+        drop(key);
+        if !remove.remove() {
+            self.tables.key_to_item.remove_exact(remove_index);
+        }
         Some(
             self.items
                 .remove(remove_index)

--- a/crates/iddqd/src/support/btree_table.rs
+++ b/crates/iddqd/src/support/btree_table.rs
@@ -26,7 +26,7 @@ thread_local! {
     ///
     /// This works by:
     ///
-    /// * We store an `Index` in the BTreeSet which knows how to call this
+    /// * We store an `Index` in the BTreeMap which knows how to call this
     ///   dynamic comparator.
     /// * When we need to compare two `Index` values, we create a CmpDropGuard.
     ///   This struct is responsible for managing the lifetime of the
@@ -49,7 +49,7 @@ thread_local! {
     ///   If and when https://github.com/rust-lang/rust/issues/133549 lands,
     ///   this should become a viable option. Worth looking out for!
     ///
-    /// * Using a third-party BTreeSet implementation that allows passing in
+    /// * Using a third-party BTreeMap implementation that allows passing in
     ///   external comparators. As of 2025-05, there appear to be two options:
     ///
     ///   1. copse (https://docs.rs/copse), which doesn't seem like a good fit
@@ -228,20 +228,6 @@ impl MapBTreeTable {
         PreparedBTreeInsert { entry }
     }
 
-    #[cfg_attr(not(test), expect(dead_code))]
-    pub(crate) fn insert<K, Q, F>(
-        &mut self,
-        index: ItemIndex,
-        key: &Q,
-        lookup: F,
-    ) where
-        K: Ord,
-        Q: ?Sized + Comparable<K>,
-        F: Fn(ItemIndex) -> K,
-    {
-        self.prepare_insert(index, key, lookup).insert();
-    }
-
     pub(crate) fn prepare_remove<K, F>(
         &mut self,
         index: ItemIndex,
@@ -260,17 +246,21 @@ impl MapBTreeTable {
         drop(guard);
 
         match entry {
+            btree_map::Entry::Vacant(_) => {
+                // The comparator-based search missed an entry that
+                // `remove_by_index` has just confirmed lives in the item set.
+                // The most likely cause is a hash-blind key mutation that
+                // `RefMut` could not detect: the tree's structural order is
+                // now wrong, so a binary search walks past the physical
+                // entry.
+                //
+                // This is a signal to the caller to fall back to the linear
+                // `remove_exact` fallback when it commits the change.
+                PreparedBTreeRemove { inner: PreparedBTreeRemoveInner::Missing }
+            }
             btree_map::Entry::Occupied(entry) => PreparedBTreeRemove {
                 inner: PreparedBTreeRemoveInner::Occupied(entry),
             },
-            btree_map::Entry::Vacant(_entry) => {
-                // Something went wrong, most likely a buggy comparator. The
-                // item is missing.
-                //
-                // This is a signal to the caller to use the linear remove_exact
-                // fallback when it gets around to committing the change.
-                PreparedBTreeRemove { inner: PreparedBTreeRemoveInner::Missing }
-            }
         }
     }
 
@@ -695,7 +685,7 @@ mod tests {
         for ix in [0u32, 2, 4] {
             let ix = ItemIndex::new(ix);
             let key = pre_lookup(ix);
-            table.insert(ix, &key, pre_lookup);
+            table.prepare_insert(ix, &key, pre_lookup).insert();
         }
         assert_eq!(table.len(), 3);
         assert_eq!(

--- a/crates/iddqd/src/support/btree_table.rs
+++ b/crates/iddqd/src/support/btree_table.rs
@@ -7,7 +7,7 @@
 use super::{ItemIndex, item_set::IndexRemap, map_hash::MapHash};
 use crate::internal::{TableValidationError, ValidateCompact};
 use alloc::{
-    collections::{BTreeSet, btree_set},
+    collections::{BTreeMap, BTreeSet, btree_map},
     vec::Vec,
 };
 use core::{
@@ -75,7 +75,7 @@ type IndexCmp<'a> = dyn Fn(&Index, &Index) -> Ordering + 'a;
 /// A B-tree-based table with an external comparator.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct MapBTreeTable {
-    items: BTreeSet<Index>,
+    items: BTreeMap<Index, ()>,
     // We use foldhash directly here because we allow compiling with std but
     // without the default-hasher. std turns on foldhash but not the default
     // hasher.
@@ -85,7 +85,7 @@ pub(crate) struct MapBTreeTable {
 impl MapBTreeTable {
     pub(crate) const fn new() -> Self {
         Self {
-            items: BTreeSet::new(),
+            items: BTreeMap::new(),
             // FixedState::with_seed XORs the passed in seed with a fixed
             // high-entropy value.
             hash_state: foldhash::fast::FixedState::with_seed(0),
@@ -117,7 +117,7 @@ impl MapBTreeTable {
                 // value should not be stored.
                 let mut indexes: Vec<ItemIndex> =
                     Vec::with_capacity(expected_len);
-                for index in &self.items {
+                for index in self.items.keys() {
                     let v = index.value();
                     if v == Index::SENTINEL_VALUE {
                         return Err(TableValidationError::new(
@@ -139,7 +139,7 @@ impl MapBTreeTable {
                 // There should be no duplicates, and the sentinel value
                 // should not be stored.
                 let indexes: Vec<ItemIndex> =
-                    self.items.iter().map(|ix| ix.value()).collect();
+                    self.items.keys().map(|ix| ix.value()).collect();
                 let index_set: BTreeSet<ItemIndex> =
                     indexes.iter().copied().collect();
                 if index_set.len() != indexes.len() {
@@ -163,12 +163,12 @@ impl MapBTreeTable {
 
     #[inline]
     pub(crate) fn first(&self) -> Option<ItemIndex> {
-        self.items.first().map(|ix| ix.value())
+        self.items.first_key_value().map(|(ix, ())| ix.value())
     }
 
     #[inline]
     pub(crate) fn last(&self) -> Option<ItemIndex> {
-        self.items.last().map(|ix| ix.value())
+        self.items.last_key_value().map(|(ix, ())| ix.value())
     }
 
     pub(crate) fn find_index<K, Q, F>(
@@ -185,11 +185,11 @@ impl MapBTreeTable {
 
         let guard = CmpDropGuard::new(&f);
 
-        let ret = match self.items.get(&Index::sentinel()) {
-            Some(ix) if ix.value() == Index::SENTINEL_VALUE => {
+        let ret = match self.items.get_key_value(&Index::sentinel()) {
+            Some((ix, ())) if ix.value() == Index::SENTINEL_VALUE => {
                 panic!("internal map shouldn't store sentinel value")
             }
-            Some(ix) => Some(ix.value()),
+            Some((ix, ())) => Some(ix.value()),
             None => {
                 // The key is not in the table.
                 None
@@ -201,6 +201,34 @@ impl MapBTreeTable {
         ret
     }
 
+    pub(crate) fn prepare_insert<K, Q, F>(
+        &mut self,
+        index: ItemIndex,
+        key: &Q,
+        lookup: F,
+    ) -> PreparedBTreeInsert<'_>
+    where
+        K: Ord,
+        Q: ?Sized + Comparable<K>,
+        F: Fn(ItemIndex) -> K,
+    {
+        let f = insert_cmp(index, key, lookup);
+        let guard = CmpDropGuard::new(&f);
+
+        let entry = match self.items.entry(Index::new(index)) {
+            btree_map::Entry::Vacant(entry) => entry,
+            btree_map::Entry::Occupied(_) => {
+                panic!("internal map already contains index {index}")
+            }
+        };
+
+        // drop(guard) isn't necessary, but we make it explicit
+        drop(guard);
+
+        PreparedBTreeInsert { entry }
+    }
+
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn insert<K, Q, F>(
         &mut self,
         index: ItemIndex,
@@ -211,27 +239,50 @@ impl MapBTreeTable {
         Q: ?Sized + Comparable<K>,
         F: Fn(ItemIndex) -> K,
     {
-        let f = insert_cmp(index, key, lookup);
-        let guard = CmpDropGuard::new(&f);
-
-        self.items.insert(Index::new(index));
-
-        // drop(guard) isn't necessary, but we make it explicit
-        drop(guard);
+        self.prepare_insert(index, key, lookup).insert();
     }
 
-    pub(crate) fn remove<K, F>(&mut self, index: ItemIndex, key: K, lookup: F)
+    pub(crate) fn prepare_remove<K, F>(
+        &mut self,
+        index: ItemIndex,
+        key: &K,
+        lookup: F,
+    ) -> PreparedBTreeRemove<'_>
     where
         F: Fn(ItemIndex) -> K,
         K: Ord,
     {
-        let f = insert_cmp(index, &key, lookup);
+        let f = insert_cmp(index, key, lookup);
         let guard = CmpDropGuard::new(&f);
-
-        self.items.remove(&Index::new(index));
+        let entry = self.items.entry(Index::new(index));
 
         // drop(guard) isn't necessary, but we make it explicit
         drop(guard);
+
+        match entry {
+            btree_map::Entry::Occupied(entry) => PreparedBTreeRemove {
+                inner: PreparedBTreeRemoveInner::Occupied(entry),
+            },
+            btree_map::Entry::Vacant(_entry) => {
+                // Something went wrong, most likely a buggy comparator. The
+                // item is missing.
+                //
+                // This is a signal to the caller to use the linear remove_exact
+                // fallback when it gets around to committing the change.
+                PreparedBTreeRemove { inner: PreparedBTreeRemoveInner::Missing }
+            }
+        }
+    }
+
+    pub(crate) fn remove_exact(&mut self, index: ItemIndex) {
+        // If an item key was changed without detection, the B-tree order can be
+        // wrong. A comparator-based search may then miss the physical entry for
+        // this index. Fall back to a linear exact-index cleanup before the
+        // item slot can be reused.
+        //
+        // (BTreeMap::retain does not re-sort the tree or recompute positions,
+        // so a comparator guard isn't necessary.)
+        self.items.retain(|stored_index, ()| stored_index.value() != index);
     }
 
     pub(crate) fn retain<F>(&mut self, mut f: F)
@@ -240,7 +291,7 @@ impl MapBTreeTable {
     {
         // We don't need to set up a comparator in the environment because
         // `retain` doesn't do any comparisons as part of its operation.
-        self.items.retain(|index| f(index.value()));
+        self.items.retain(|index, ()| f(index.value()));
     }
 
     /// Rewrites every stored index via `remap`.
@@ -262,7 +313,7 @@ impl MapBTreeTable {
     /// [`ItemSet::shrink_to_fit`]: super::item_set::ItemSet::shrink_to_fit
     /// [`ItemSet::shrink_to`]: super::item_set::ItemSet::shrink_to
     pub(crate) fn remap_indexes(&mut self, remap: &IndexRemap) {
-        for idx in self.items.iter() {
+        for idx in self.items.keys() {
             let new = remap.remap(idx.value());
             idx.set_value(new);
         }
@@ -275,7 +326,7 @@ impl MapBTreeTable {
     }
 
     pub(crate) fn iter(&self) -> Iter<'_> {
-        Iter::new(self.items.iter())
+        Iter::new(self.items.keys())
     }
 
     pub(crate) fn into_iter(self) -> IntoIter {
@@ -293,11 +344,11 @@ impl MapBTreeTable {
 
 #[derive(Clone, Debug)]
 pub(crate) struct Iter<'a> {
-    inner: btree_set::Iter<'a, Index>,
+    inner: btree_map::Keys<'a, Index, ()>,
 }
 
 impl<'a> Iter<'a> {
-    fn new(inner: btree_set::Iter<'a, Index>) -> Self {
+    fn new(inner: btree_map::Keys<'a, Index, ()>) -> Self {
         Self { inner }
     }
 
@@ -316,11 +367,11 @@ impl<'a> Iterator for Iter<'a> {
 
 #[derive(Debug)]
 pub(crate) struct IntoIter {
-    inner: btree_set::IntoIter<Index>,
+    inner: btree_map::IntoIter<Index, ()>,
 }
 
 impl IntoIter {
-    fn new(inner: btree_set::IntoIter<Index>) -> Self {
+    fn new(inner: btree_map::IntoIter<Index, ()>) -> Self {
         Self { inner }
     }
 }
@@ -329,7 +380,38 @@ impl Iterator for IntoIter {
     type Item = ItemIndex;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|index| index.value())
+        self.inner.next().map(|(index, ())| index.value())
+    }
+}
+
+pub(crate) struct PreparedBTreeInsert<'a> {
+    entry: btree_map::VacantEntry<'a, Index, ()>,
+}
+
+impl PreparedBTreeInsert<'_> {
+    pub(crate) fn insert(self) {
+        self.entry.insert(());
+    }
+}
+
+pub(crate) struct PreparedBTreeRemove<'a> {
+    inner: PreparedBTreeRemoveInner<'a>,
+}
+
+enum PreparedBTreeRemoveInner<'a> {
+    Occupied(btree_map::OccupiedEntry<'a, Index, ()>),
+    Missing,
+}
+
+impl PreparedBTreeRemove<'_> {
+    pub(crate) fn remove(self) -> bool {
+        match self.inner {
+            PreparedBTreeRemoveInner::Occupied(entry) => {
+                entry.remove_entry();
+                true
+            }
+            PreparedBTreeRemoveInner::Missing => false,
+        }
     }
 }
 
@@ -619,7 +701,7 @@ mod tests {
         assert_eq!(
             table
                 .items
-                .iter()
+                .keys()
                 .map(|i| i.value().as_u32())
                 .collect::<alloc::vec::Vec<_>>(),
             [0u32, 2, 4],
@@ -636,7 +718,7 @@ mod tests {
         assert_eq!(
             table
                 .items
-                .iter()
+                .keys()
                 .map(|i| i.value().as_u32())
                 .collect::<alloc::vec::Vec<_>>(),
             [0u32, 1, 2],

--- a/crates/iddqd/tests/integration/bi_hash_map.rs
+++ b/crates/iddqd/tests/integration/bi_hash_map.rs
@@ -1241,8 +1241,9 @@ impl BiHashItem for PanickyHashItem {
 mod proptest_panic_safety {
     use super::*;
     use crate::panic_safety::{
-        PanicSafety, PanickyKey, PanickyOp, assert_panic_fired_as_expected,
-        assert_post_op_invariants, run_armed, sorted_keys,
+        PanicSafety, PanickyOp, PanickySearchKey,
+        assert_panic_fired_as_expected, assert_post_op_invariants, run_armed,
+        sorted_keys,
     };
 
     // Keys are kept in a small range so hits and misses both happen
@@ -1319,22 +1320,22 @@ mod proptest_panic_safety {
                         map.insert_overwrite(PanickyHashItem { key1, key2 });
                 }
                 PanickyAction::Remove1(key1) => {
-                    let _ = map.remove1(&PanickyKey(key1));
+                    let _ = map.remove1(&PanickySearchKey(key1));
                 }
                 PanickyAction::Remove2(key2) => {
-                    let _ = map.remove2(&PanickyKey(key2));
+                    let _ = map.remove2(&PanickySearchKey(key2));
                 }
                 PanickyAction::Get1(key1) => {
-                    let _ = map.get1(&PanickyKey(key1));
+                    let _ = map.get1(&PanickySearchKey(key1));
                 }
                 PanickyAction::Get2(key2) => {
-                    let _ = map.get2(&PanickyKey(key2));
+                    let _ = map.get2(&PanickySearchKey(key2));
                 }
                 PanickyAction::ContainsKey1(key1) => {
-                    let _ = map.contains_key1(&PanickyKey(key1));
+                    let _ = map.contains_key1(&PanickySearchKey(key1));
                 }
                 PanickyAction::ContainsKey2(key2) => {
-                    let _ = map.contains_key2(&PanickyKey(key2));
+                    let _ = map.contains_key2(&PanickySearchKey(key2));
                 }
                 PanickyAction::RetainModulo(rem, modulo, keep) => {
                     map.retain(|item| {
@@ -1395,8 +1396,8 @@ mod proptest_panic_safety {
                 &pre_state,
                 &post_state,
                 |&(k1, k2)| {
-                    map.contains_key1(&PanickyKey(k1))
-                        && map.contains_key2(&PanickyKey(k2))
+                    map.contains_key1(&PanickySearchKey(k1))
+                        && map.contains_key2(&PanickySearchKey(k2))
                 },
             );
         }

--- a/crates/iddqd/tests/integration/id_hash_map.rs
+++ b/crates/iddqd/tests/integration/id_hash_map.rs
@@ -911,8 +911,9 @@ impl IdHashItem for PanickyHashItem {
 mod proptest_panic_safety {
     use super::*;
     use crate::panic_safety::{
-        PanicSafety, PanickyKey, PanickyOp, assert_panic_fired_as_expected,
-        assert_post_op_invariants, run_armed, sorted_keys,
+        PanicSafety, PanickyOp, PanickySearchKey,
+        assert_panic_fired_as_expected, assert_post_op_invariants, run_armed,
+        sorted_keys,
     };
 
     // Keys are kept in a small range so collisions, hits, and misses
@@ -969,13 +970,13 @@ mod proptest_panic_safety {
                     let _ = map.insert_overwrite(PanickyHashItem { key });
                 }
                 PanickyAction::Remove(key) => {
-                    let _ = map.remove(&PanickyKey(key));
+                    let _ = map.remove(&PanickySearchKey(key));
                 }
                 PanickyAction::Get(key) => {
-                    let _ = map.get(&PanickyKey(key));
+                    let _ = map.get(&PanickySearchKey(key));
                 }
                 PanickyAction::ContainsKey(key) => {
-                    let _ = map.contains_key(&PanickyKey(key));
+                    let _ = map.contains_key(&PanickySearchKey(key));
                 }
                 PanickyAction::RetainModulo(rem, modulo, keep) => {
                     map.retain(|item| {
@@ -1033,7 +1034,7 @@ mod proptest_panic_safety {
                 panic_safety,
                 &pre_state,
                 &post_state,
-                |&k| map.contains_key(&PanickyKey(k)),
+                |&k| map.contains_key(&PanickySearchKey(k)),
             );
         }
     }

--- a/crates/iddqd/tests/integration/id_ord_map.rs
+++ b/crates/iddqd/tests/integration/id_ord_map.rs
@@ -1107,8 +1107,9 @@ impl IdOrdItem for PanickyOrdItem {
 mod proptest_panic_safety {
     use super::*;
     use crate::panic_safety::{
-        PanicSafety, PanickyKey, PanickyOp, assert_panic_fired_as_expected,
-        assert_post_op_invariants, run_armed, sorted_keys,
+        PanicSafety, PanickyOp, PanickySearchKey,
+        assert_panic_fired_as_expected, assert_post_op_invariants, run_armed,
+        sorted_keys,
     };
 
     // Keys are kept in a small range so hits and misses both happen
@@ -1169,13 +1170,13 @@ mod proptest_panic_safety {
                     let _ = map.insert_overwrite(PanickyOrdItem { key });
                 }
                 PanickyAction::Remove(key) => {
-                    let _ = map.remove(&PanickyKey(key));
+                    let _ = map.remove(&PanickySearchKey(key));
                 }
                 PanickyAction::Get(key) => {
-                    let _ = map.get(&PanickyKey(key));
+                    let _ = map.get(&PanickySearchKey(key));
                 }
                 PanickyAction::ContainsKey(key) => {
-                    let _ = map.contains_key(&PanickyKey(key));
+                    let _ = map.contains_key(&PanickySearchKey(key));
                 }
                 PanickyAction::PopFirst => {
                     let _ = map.pop_first();
@@ -1240,7 +1241,7 @@ mod proptest_panic_safety {
                 panic_safety,
                 &pre_state,
                 &post_state,
-                |&k| map.contains_key(&PanickyKey(k)),
+                |&k| map.contains_key(&PanickySearchKey(k)),
             );
         }
     }

--- a/crates/iddqd/tests/integration/panic_safety.rs
+++ b/crates/iddqd/tests/integration/panic_safety.rs
@@ -1,8 +1,12 @@
 //! Shared scaffolding for panic safety tests.
 //!
-//! [`PanickyKey`] is a key whose `Hash`/`Eq`/`Ord` impls share a thread-local
-//! panic countdown. The call after `n` successful ones panics. Each proptest
-//! drives a random sequence of [`PanickyOp`]s, and after every step asserts:
+//! [`PanickyKey`] is a key whose `Hash`/`Eq`/`Ord`/`Drop` impls share a
+//! thread-local panic countdown. The call after `n` successful ones panics.
+//! Drop is included so the harness also exercises the post-`prepare_*`,
+//! pre-commit windows in `IdOrdMap` (and analogous windows in the hash
+//! maps) where a user-key Drop is the only thing that could panic. Each
+//! proptest drives a random sequence of [`PanickyOp`]s, and after every
+//! step asserts:
 //!
 //! * `validate()`
 //! * a `contains_key` round-trip on every surviving item
@@ -15,6 +19,7 @@ use core::{
     fmt,
     hash::{Hash, Hasher},
 };
+use equivalent::{Comparable, Equivalent};
 use iddqd_test_utils::unwind::catch_panic;
 use proptest::prelude::*;
 
@@ -23,21 +28,73 @@ thread_local! {
     static OP_COUNT: Cell<u32> = const { Cell::new(0) };
 }
 
-/// A key whose `Hash`/`Eq`/`Ord` impls share a panic countdown, so
-/// tests can deterministically trigger a panic at a chosen point.
+/// A key whose `Hash`/`Eq`/`Ord`/`Drop` impls share a panic countdown,
+/// so tests can deterministically trigger a panic at a chosen point.
 #[derive(Clone, Debug, Eq)]
 pub(crate) struct PanickyKey(pub u32);
 
 impl PanickyKey {
     fn observe_call(label: &'static str) {
-        OP_COUNT.with(|c| c.set(c.get() + 1));
         PANIC_COUNTDOWN.with(|c| {
+            // When disarmed, don't tick `OP_COUNT`. This matters for two
+            // distinct cases:
+            //
+            // * Calls outside `run_armed` (validation, assertions): they
+            //   shouldn't count toward the next armed step.
+            // * Calls during panic unwinding *after* the countdown has fired:
+            //   key drops along the unwind path would otherwise tick
+            //   `OP_COUNT` past `n + 1` and break
+            //   `assert_panic_fired_as_expected`.
             let Some(n) = c.get() else { return };
+            OP_COUNT.with(|c| c.set(c.get() + 1));
             if n == 0 {
+                // Disarm before panicking so additional `observe_call`s
+                // during unwinding (notably key drops) don't double-panic.
+                c.set(None);
                 panic!("PanickyKey::{label} panic triggered");
             }
             c.set(Some(n - 1));
         });
+    }
+}
+
+impl Drop for PanickyKey {
+    fn drop(&mut self) {
+        Self::observe_call("drop");
+    }
+}
+
+/// Caller-side lookup key.
+///
+/// Shares `PanickyKey`'s countdown for `Hash`/`Eq`/`Ord` so the harness
+/// still exercises mid-op panics from comparator calls. Deliberately does
+/// **not** panic from `Drop`: a search key is constructed by the caller,
+/// passed by reference into a map op, and dropped *after* the op returns
+/// (per Rust temporary lifetime rules). A `Drop` panic at that point isn't
+/// within the map's atomic-op window, so observing it would conflate
+/// post-op cleanup with mid-op failures and spuriously flag atomic ops as
+/// violating their invariant.
+#[derive(Clone, Debug)]
+pub(crate) struct PanickySearchKey(pub u32);
+
+impl Hash for PanickySearchKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        PanickyKey::observe_call("search-hash");
+        self.0.hash(state);
+    }
+}
+
+impl Equivalent<PanickyKey> for PanickySearchKey {
+    fn equivalent(&self, key: &PanickyKey) -> bool {
+        PanickyKey::observe_call("search-equivalent");
+        self.0 == key.0
+    }
+}
+
+impl Comparable<PanickyKey> for PanickySearchKey {
+    fn compare(&self, key: &PanickyKey) -> Ordering {
+        PanickyKey::observe_call("search-compare");
+        self.0.cmp(&key.0)
     }
 }
 
@@ -124,6 +181,7 @@ pub(crate) fn run_armed(armed: Option<u32>, f: impl FnOnce()) -> (bool, u32) {
 /// Asserts that the panic-countdown infrastructure fired (or didn't)
 /// exactly as the arming would predict.
 ///
+/// "Key call" here means any of `Hash`/`Eq`/`Ord`/`Drop` on `PanickyKey`.
 /// With `armed = Some(n)`, the panic should fire on the `(n+1)`-th key
 /// call, so `panicked` implies `ops == n + 1`, and `!panicked` implies
 /// the action made at most `n` key calls. With `armed = None`, no

--- a/crates/iddqd/tests/integration/pathological.rs
+++ b/crates/iddqd/tests/integration/pathological.rs
@@ -7,8 +7,9 @@
 use crate::panic_safety::{PanickyKey, arm_panic_after, disarm_panic};
 use core::cell::Cell;
 use iddqd::{
-    BiHashItem, BiHashMap, Equivalent, IdHashItem, IdHashMap, IdOrdItem,
-    IdOrdMap, TriHashItem, TriHashMap, bi_upcast, id_ord_map, id_upcast,
+    BiHashItem, BiHashMap, Comparable, Equivalent, IdHashItem, IdHashMap,
+    IdOrdItem, IdOrdMap, TriHashItem, TriHashMap, bi_upcast, id_ord_map,
+    id_upcast,
     internal::{ValidateChaos, ValidateCompact},
     tri_upcast,
 };
@@ -52,6 +53,130 @@ impl IdOrdItem for PanickyItem {
         PanickyKey(self.id)
     }
     id_upcast!();
+}
+
+thread_local! {
+    static DROP_PANIC_KEY_CALLS: Cell<u32> = const { Cell::new(0) };
+    static DROP_PANIC_ON_KEY_DROP: Cell<Option<u32>> = const { Cell::new(None) };
+}
+
+#[derive(Debug)]
+struct DropPanicOrdItem {
+    id: u32,
+}
+
+#[derive(Debug, Eq)]
+struct DropPanicOrdKey {
+    id: u32,
+    key_call: u32,
+}
+
+impl DropPanicOrdKey {
+    fn new(id: u32) -> Self {
+        let key_call = DROP_PANIC_KEY_CALLS.with(|c| {
+            let next = c.get() + 1;
+            c.set(next);
+            next
+        });
+        Self { id, key_call }
+    }
+}
+
+impl Drop for DropPanicOrdKey {
+    fn drop(&mut self) {
+        DROP_PANIC_ON_KEY_DROP.with(|c| {
+            if c.get() == Some(self.key_call) {
+                panic!(
+                    "DropPanicOrdKey drop panic on key call {}",
+                    self.key_call
+                );
+            }
+        });
+    }
+}
+
+impl PartialEq for DropPanicOrdKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl PartialOrd for DropPanicOrdKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DropPanicOrdKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+struct DropPanicLookup(u32);
+
+impl Equivalent<DropPanicOrdKey> for DropPanicLookup {
+    fn equivalent(&self, key: &DropPanicOrdKey) -> bool {
+        self.0 == key.id
+    }
+}
+
+impl Comparable<DropPanicOrdKey> for DropPanicLookup {
+    fn compare(&self, key: &DropPanicOrdKey) -> Ordering {
+        self.0.cmp(&key.id)
+    }
+}
+
+impl IdOrdItem for DropPanicOrdItem {
+    type Key<'a> = DropPanicOrdKey;
+
+    fn key(&self) -> Self::Key<'_> {
+        DropPanicOrdKey::new(self.id)
+    }
+
+    id_upcast!();
+}
+
+fn reset_drop_panic_ord_key() {
+    DROP_PANIC_KEY_CALLS.with(|c| c.set(0));
+    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(None));
+}
+
+#[test]
+fn id_ord_insert_key_drop_panic_leaves_map_valid() {
+    let mut map = IdOrdMap::<DropPanicOrdItem>::new();
+
+    reset_drop_panic_ord_key();
+    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(Some(2)));
+    let panicked = catch_panic(|| {
+        map.insert_unique(DropPanicOrdItem { id: 1 }).unwrap();
+    })
+    .is_none();
+    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(None));
+    assert!(panicked);
+
+    let validation =
+        map.validate(ValidateCompact::NonCompact, ValidateChaos::No);
+    assert!(validation.is_ok(), "{validation:?}");
+}
+
+#[test]
+fn id_ord_remove_key_drop_panic_leaves_map_valid() {
+    let mut map = IdOrdMap::<DropPanicOrdItem>::new();
+    map.insert_unique(DropPanicOrdItem { id: 1 }).unwrap();
+
+    reset_drop_panic_ord_key();
+    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(Some(2)));
+    let panicked = catch_panic(|| {
+        let _ = map.remove(&DropPanicLookup(1));
+    })
+    .is_none();
+    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(None));
+    assert!(panicked);
+
+    let validation =
+        map.validate(ValidateCompact::NonCompact, ValidateChaos::No);
+    assert!(validation.is_ok(), "{validation:?}");
 }
 
 // Test: `OuterItem::key()` calls into a different `IdOrdMap`, so the inner
@@ -548,6 +673,64 @@ impl IdOrdItem for LyingOrdItem {
     id_upcast!();
 }
 
+#[derive(Debug)]
+struct HashBlindOrdItem {
+    id: u32,
+    value: u32,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct HashBlindOrdKey {
+    id: u32,
+}
+
+impl Hash for HashBlindOrdKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // `IdOrdMap::RefMut` detects key changes by hashing the key before and
+        // after the mutable borrow. A user key can defeat that check by
+        // colliding all key hashes.
+        0u32.hash(state);
+    }
+}
+
+impl IdOrdItem for HashBlindOrdItem {
+    type Key<'a> = HashBlindOrdKey;
+    fn key(&self) -> Self::Key<'_> {
+        HashBlindOrdKey { id: self.id }
+    }
+    id_upcast!();
+}
+
+#[test]
+fn id_ord_hash_blind_key_change_remove_reinsert_iter_mut_no_aliasing() {
+    let mut map = IdOrdMap::<HashBlindOrdItem>::new();
+    for i in 0..64 {
+        map.insert_unique(HashBlindOrdItem { id: i, value: 0 }).unwrap();
+    }
+
+    // This changes the key's ordering position without changing its hash, so
+    // `RefMut` drop does not catch it. The B-tree is now logically misordered.
+    {
+        let mut item = map.get_mut(&HashBlindOrdKey { id: 0 }).unwrap();
+        item.id = 10_000;
+    }
+
+    // `pop_first` sees the structurally first index. Removal must clear that
+    // exact index from the B-tree even though comparator-based search would be
+    // confused by the changed key.
+    let removed = map.pop_first().unwrap();
+    assert_eq!(removed.id, 10_000);
+
+    // The item set reuses the removed slot. If the old B-tree entry was left
+    // behind, iter_mut would yield two RefMuts to this same slot.
+    map.insert_unique(HashBlindOrdItem { id: 20_000, value: 0 }).unwrap();
+
+    let mut items: Vec<_> = map.iter_mut().collect();
+    for item in &mut items {
+        item.value += 1;
+    }
+}
+
 #[test]
 fn lying_ord_iter_mut_no_duplicate_yield() {
     let mut map = IdOrdMap::<LyingOrdItem>::new();
@@ -584,16 +767,8 @@ fn lying_ord_remove_reinsert_iter_mut_no_aliasing() {
             // Now switch the Ord implementation to always return
             // `Ordering::Less`.
             LIE_ORD.with(|c| c.set(Some(Ordering::Less)));
-            // In btree_table.rs, insert_cmp has a short-circuit for identical
-            // indexes. That short-circuit is load-bearing!
-            //
-            // With or without insert_cmp short-circuiting, the remove operation
-            // always succeeds from the ItemSet.
-            //
-            // * With the short-circuit, the remove additionally always succeeds
-            //   from the B-tree table.
-            // * But without it, the index 0 would be removed from the ItemSet but
-            //   _not_ be cleared from the B-tree table.
+            // Removal must not be confused by the pathological comparator: it
+            // has already selected the exact index being removed.
             entry.remove()
         }
         id_ord_map::Entry::Vacant(_) => panic!("id 0 should be present"),
@@ -601,14 +776,10 @@ fn lying_ord_remove_reinsert_iter_mut_no_aliasing() {
     assert_eq!(removed.id, 0);
 
     // Now insert an item with a comparator which always returns
-    // `Ordering::Greater`. The item set will always allocate the index 0 to the
-    // new item (since it uses LRU semantics for the free chain). But if a
-    // previous index 0 got left behind due to the lack of short-circuiting, the
-    // B-tree table will end up storing two copies of the index 0. When
-    // iterating over the map, we'll end up handing out two mutable aliases to
-    // the item we just inserted at index 0 (and miri will fail accordingly).
-    //
-    // This demonstrates that short-circuiting is necessary for soundness.
+    // `Ordering::Greater`. The item set will allocate index 0 to the new item
+    // because it uses LRU semantics for the free chain. If the previous index 0
+    // was left behind in the B-tree table, iter_mut would hand out two mutable
+    // aliases to the item we just inserted at index 0.
     LIE_ORD.with(|c| c.set(Some(Ordering::Greater)));
     map.insert_unique(LyingOrdItem { id: 10_000, value: 0 }).unwrap();
     LIE_ORD.with(|c| c.set(None));

--- a/crates/iddqd/tests/integration/pathological.rs
+++ b/crates/iddqd/tests/integration/pathological.rs
@@ -56,8 +56,11 @@ impl IdOrdItem for PanickyItem {
 }
 
 thread_local! {
-    static DROP_PANIC_KEY_CALLS: Cell<u32> = const { Cell::new(0) };
-    static DROP_PANIC_ON_KEY_DROP: Cell<Option<u32>> = const { Cell::new(None) };
+    /// When `Some(n)`, the `n`-th subsequent `DropPanicOrdKey::drop` panics.
+    /// Counts physical drops rather than `key()` calls, so the trigger is
+    /// robust to refactors that create more or fewer keys during an
+    /// operation.
+    static DROPS_UNTIL_PANIC: Cell<Option<u32>> = const { Cell::new(None) };
 }
 
 #[derive(Debug)]
@@ -68,29 +71,19 @@ struct DropPanicOrdItem {
 #[derive(Debug, Eq)]
 struct DropPanicOrdKey {
     id: u32,
-    key_call: u32,
-}
-
-impl DropPanicOrdKey {
-    fn new(id: u32) -> Self {
-        let key_call = DROP_PANIC_KEY_CALLS.with(|c| {
-            let next = c.get() + 1;
-            c.set(next);
-            next
-        });
-        Self { id, key_call }
-    }
 }
 
 impl Drop for DropPanicOrdKey {
     fn drop(&mut self) {
-        DROP_PANIC_ON_KEY_DROP.with(|c| {
-            if c.get() == Some(self.key_call) {
-                panic!(
-                    "DropPanicOrdKey drop panic on key call {}",
-                    self.key_call
-                );
+        DROPS_UNTIL_PANIC.with(|c| match c.get() {
+            None | Some(0) => {}
+            Some(1) => {
+                // Disarm before panicking so additional drops during
+                // unwinding don't double-panic and abort the process.
+                c.set(None);
+                panic!("DropPanicOrdKey drop panic");
             }
+            Some(n) => c.set(Some(n - 1)),
         });
     }
 }
@@ -131,29 +124,50 @@ impl IdOrdItem for DropPanicOrdItem {
     type Key<'a> = DropPanicOrdKey;
 
     fn key(&self) -> Self::Key<'_> {
-        DropPanicOrdKey::new(self.id)
+        DropPanicOrdKey { id: self.id }
     }
 
     id_upcast!();
-}
-
-fn reset_drop_panic_ord_key() {
-    DROP_PANIC_KEY_CALLS.with(|c| c.set(0));
-    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(None));
 }
 
 #[test]
 fn id_ord_insert_key_drop_panic_leaves_map_valid() {
     let mut map = IdOrdMap::<DropPanicOrdItem>::new();
 
-    reset_drop_panic_ord_key();
-    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(Some(2)));
+    // Panic on the *first* key drop after arming. The exact code path exercised
+    // depends on the impl, but the broader claim is that a key `Drop` panic at
+    // any point during `insert_unique` must leave the map valid.
+    DROPS_UNTIL_PANIC.with(|c| c.set(Some(1)));
     let panicked = catch_panic(|| {
-        map.insert_unique(DropPanicOrdItem { id: 1 }).unwrap();
+        map.insert_unique(DropPanicOrdItem { id: 1 })
+            .expect("insert_unique should not return Err here");
     })
     .is_none();
-    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(None));
-    assert!(panicked);
+    assert!(panicked, "expected the armed key Drop to panic the insert");
+
+    let validation =
+        map.validate(ValidateCompact::NonCompact, ValidateChaos::No);
+    assert!(validation.is_ok(), "{validation:?}");
+}
+
+#[test]
+fn id_ord_insert_key_drop_panic_during_commit_leaves_map_valid() {
+    let mut map = IdOrdMap::<DropPanicOrdItem>::new();
+
+    // Skip the first drop (which falls in the duplicate-check window) and panic
+    // on the second, which lands between `prepare_insert` and the final commit.
+    // This is why IdOrdMap uses two-phase commit.
+    //
+    // If a future refactor stops creating a second key, this test fails loudly
+    // via `assert!(panicked)`. (At that point the test should maybe be
+    // deleted.)
+    DROPS_UNTIL_PANIC.with(|c| c.set(Some(2)));
+    let panicked = catch_panic(|| {
+        map.insert_unique(DropPanicOrdItem { id: 1 })
+            .expect("insert_unique should not return Err here");
+    })
+    .is_none();
+    assert!(panicked, "expected the armed key Drop to panic the insert");
 
     let validation =
         map.validate(ValidateCompact::NonCompact, ValidateChaos::No);
@@ -163,16 +177,18 @@ fn id_ord_insert_key_drop_panic_leaves_map_valid() {
 #[test]
 fn id_ord_remove_key_drop_panic_leaves_map_valid() {
     let mut map = IdOrdMap::<DropPanicOrdItem>::new();
-    map.insert_unique(DropPanicOrdItem { id: 1 }).unwrap();
+    map.insert_unique(DropPanicOrdItem { id: 1 })
+        .expect("insert_unique on fresh map should succeed");
 
-    reset_drop_panic_ord_key();
-    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(Some(2)));
+    // The remove path constructs one key before the prepare/commit window
+    // and drops it inside that window, so panicking on the first drop lands
+    // the panic in the post-`prepare_remove`, pre-commit drop.
+    DROPS_UNTIL_PANIC.with(|c| c.set(Some(1)));
     let panicked = catch_panic(|| {
         let _ = map.remove(&DropPanicLookup(1));
     })
     .is_none();
-    DROP_PANIC_ON_KEY_DROP.with(|c| c.set(None));
-    assert!(panicked);
+    assert!(panicked, "expected the armed key Drop to panic the remove");
 
     let validation =
         map.validate(ValidateCompact::NonCompact, ValidateChaos::No);

--- a/crates/iddqd/tests/integration/tri_hash_map.rs
+++ b/crates/iddqd/tests/integration/tri_hash_map.rs
@@ -1123,8 +1123,9 @@ impl TriHashItem for PanickyHashItem {
 mod proptest_panic_safety {
     use super::*;
     use crate::panic_safety::{
-        PanicSafety, PanickyKey, PanickyOp, assert_panic_fired_as_expected,
-        assert_post_op_invariants, run_armed, sorted_keys,
+        PanicSafety, PanickyOp, PanickySearchKey,
+        assert_panic_fired_as_expected, assert_post_op_invariants, run_armed,
+        sorted_keys,
     };
 
     // Keys are kept in a small range so hits and misses both happen
@@ -1215,22 +1216,22 @@ mod proptest_panic_safety {
                     });
                 }
                 PanickyAction::Remove1(key1) => {
-                    let _ = map.remove1(&PanickyKey(key1));
+                    let _ = map.remove1(&PanickySearchKey(key1));
                 }
                 PanickyAction::Remove2(key2) => {
-                    let _ = map.remove2(&PanickyKey(key2));
+                    let _ = map.remove2(&PanickySearchKey(key2));
                 }
                 PanickyAction::Remove3(key3) => {
-                    let _ = map.remove3(&PanickyKey(key3));
+                    let _ = map.remove3(&PanickySearchKey(key3));
                 }
                 PanickyAction::Get1(key1) => {
-                    let _ = map.get1(&PanickyKey(key1));
+                    let _ = map.get1(&PanickySearchKey(key1));
                 }
                 PanickyAction::Get2(key2) => {
-                    let _ = map.get2(&PanickyKey(key2));
+                    let _ = map.get2(&PanickySearchKey(key2));
                 }
                 PanickyAction::Get3(key3) => {
-                    let _ = map.get3(&PanickyKey(key3));
+                    let _ = map.get3(&PanickySearchKey(key3));
                 }
                 PanickyAction::RetainModulo(rem, modulo, keep) => {
                     map.retain(|item| {
@@ -1295,9 +1296,9 @@ mod proptest_panic_safety {
                 &pre_state,
                 &post_state,
                 |&(k1, k2, k3)| {
-                    map.contains_key1(&PanickyKey(k1))
-                        && map.contains_key2(&PanickyKey(k2))
-                        && map.contains_key3(&PanickyKey(k3))
+                    map.contains_key1(&PanickySearchKey(k1))
+                        && map.contains_key2(&PanickySearchKey(k2))
+                        && map.contains_key3(&PanickySearchKey(k3))
                 },
             );
         }


### PR DESCRIPTION
* Use a two-phase commit pattern where no user code runs in between changing the btree table and changing the map. This requires switching over from `BTreeSet` to `BTreeMap<_, ()>`, but that is just what's required to be able to express this pattern.
* If, for whatever reason (either a buggy comparator or some `RefMut` trickery), an efficient remove lookup didn't work, switch to a linear scan to ensure the index is removed. This ends up being load-bearing for aliasing.
* Extend the panic safety tests to also cover `Drop`.