### PR TITLE
implement linear-scan fallback for removing from hash maps

### DIFF
--- a/crates/iddqd/src/bi_hash_map/imp.rs
+++ b/crates/iddqd/src/bi_hash_map/imp.rs
@@ -2177,26 +2177,36 @@ impl<T: BiHashItem, S: Clone + BuildHasher, A: Allocator> BiHashMap<T, S, A> {
         // pathological. hashbrown's `find_entry_by_hash` is panic-safe because
         // the table is not mutated until `OccupiedEntry::remove` is called, so
         // a panic while hashing leaves items and both tables unmodified.
+        // (Unlike the IdOrdMap path, no separate two-phase commit is needed:
+        // the BTreeMap analog has to guard against a user-`Ord` panic during
+        // the tree walk, but the hash walk here never invokes user code.)
+        //
+        // If either hash lookup misses — which happens when a `mem::forget`
+        // on a `RefMut` bypassed the drop-time hash check and one of the
+        // item's keys now hashes to a different bucket than its entry sits
+        // in — fall back to a linear scan by `ItemIndex` for that table.
+        // The fallback never invokes user `Hash`, so cleanup remains
+        // panic-safe.
         let item = self.items.get(remove_index)?;
         let state = &self.tables.state;
         let hash1 = state.hash_one(item.key1());
         let hash2 = state.hash_one(item.key2());
-        let Ok(entry1) = self
+        match self
             .tables
             .k1_to_item
             .find_entry_by_hash(hash1, |index| index == remove_index)
-        else {
-            panic!("remove_index {remove_index} not found in k1_to_item");
-        };
-        let Ok(entry2) = self
+        {
+            Ok(entry) => entry.remove(),
+            Err(()) => self.tables.k1_to_item.remove_by_index(remove_index),
+        }
+        match self
             .tables
             .k2_to_item
             .find_entry_by_hash(hash2, |index| index == remove_index)
-        else {
-            panic!("remove_index {remove_index} not found in k2_to_item");
-        };
-        entry1.remove();
-        entry2.remove();
+        {
+            Ok(entry) => entry.remove(),
+            Err(()) => self.tables.k2_to_item.remove_by_index(remove_index),
+        }
         Some(
             self.items
                 .remove(remove_index)

--- a/crates/iddqd/src/id_hash_map/imp.rs
+++ b/crates/iddqd/src/id_hash_map/imp.rs
@@ -1417,20 +1417,35 @@ impl<T: IdHashItem, S: Clone + BuildHasher, A: Allocator> IdHashMap<T, S, A> {
         // and items in sequence. This lookup deliberately matches by
         // `ItemIndex` rather than by user `Eq`: at this point we already know
         // which item is being removed, and user `Eq` might be pathological.
+        //
         // hashbrown's `find_entry_by_hash` is panic-safe because the table is
         // not mutated until `OccupiedEntry::remove` is called, so a panic while
-        // hashing leaves both items and the table unmodified.
+        // hashing leaves both items and the table unmodified. (Unlike the
+        // IdOrdMap path, we don't need a separate two-phase commit: the
+        // BTreeMap analog has to guard against a user-`Ord` panic during the
+        // tree walk, but the hash walk here never invokes user code.)
+        //
+        // If the hash lookup misses, which can happen when `mem::forget` is
+        // called on a `RefMut` after the ID was changed, the item's current key
+        // now hashes to a different bucket than the one its entry sits in. In
+        // that case, we fall back to a linear scan by `ItemIndex`. This keeps
+        // the table and item set consistent with each other across silent key
+        // mutations, mirroring `MapBTreeTable::remove_exact`.
+        //
+        // This is not expected to be the common case (why are you calling
+        // mem::forget on a RefMut?), but guarding against it explicitly makes
+        // our invariants easier to reason about.
         let item = self.items.get(remove_index)?;
         let state = &self.tables.state;
         let hash = state.hash_one(item.key());
-        let Ok(entry) = self
+        match self
             .tables
             .key_to_item
             .find_entry_by_hash(hash, |index| index == remove_index)
-        else {
-            panic!("remove_index {remove_index} not found in key_to_item");
-        };
-        entry.remove();
+        {
+            Ok(entry) => entry.remove(),
+            Err(()) => self.tables.key_to_item.remove_by_index(remove_index),
+        }
         Some(
             self.items
                 .remove(remove_index)

--- a/crates/iddqd/src/support/hash_table.rs
+++ b/crates/iddqd/src/support/hash_table.rs
@@ -203,21 +203,20 @@ impl<A: Allocator> MapHashTable<A> {
         self.items.retain(|stored| f(stored.ix));
     }
 
-    /// Removes the entry whose stored index is `ix`.
+    /// Removes the entry whose stored index is `ix` using a linear scan.
     ///
-    /// Does not invoke user `Hash`: `hashbrown::HashTable::retain` calls
-    /// only the predicate and does not rehash, so the linear scan stays
-    /// panic-free even when a `find_entry_by_hash` miss brought us here.
+    /// Used as the cleanup path after a `find_entry_by_hash` miss caused by a
+    /// silent key mutation (e.g. `mem::forget` on `RefMut`). The caller has
+    /// already identified the `ItemIndex` to remove and needs a removal that
+    /// does not re-enter user code.
     ///
-    /// Used as the cleanup path after a `find_entry_by_hash` miss caused by
-    /// a silent key mutation (e.g. `mem::forget` on `RefMut`): the caller
-    /// has already identified the target slot by `ItemIndex` and needs a
-    /// removal that does not re-enter user code.
+    /// The table holds at most one entry per `ItemIndex` (that is the
+    /// overarching invariant we're trying to uphold across this crate), so this
+    /// removes at most one entry.
     ///
-    /// The table holds at most one entry per `ItemIndex`, so this removes
-    /// at most one entry. Panics if no such entry exists — reaching this
-    /// state means the table and item set had already diverged before the
-    /// call, which is a hard invariant violation.
+    /// Panics if no such entry exists. Reaching this state means the table and
+    /// item set had already diverged before the call, at which point we can no
+    /// longer reason about the map.
     pub(crate) fn remove_by_index(&mut self, ix: ItemIndex) {
         let mut found = false;
         self.items.retain(|stored| {

--- a/crates/iddqd/src/support/hash_table.rs
+++ b/crates/iddqd/src/support/hash_table.rs
@@ -203,6 +203,37 @@ impl<A: Allocator> MapHashTable<A> {
         self.items.retain(|stored| f(stored.ix));
     }
 
+    /// Removes the entry whose stored index is `ix`.
+    ///
+    /// Does not invoke user `Hash`: `hashbrown::HashTable::retain` calls
+    /// only the predicate and does not rehash, so the linear scan stays
+    /// panic-free even when a `find_entry_by_hash` miss brought us here.
+    ///
+    /// Used as the cleanup path after a `find_entry_by_hash` miss caused by
+    /// a silent key mutation (e.g. `mem::forget` on `RefMut`): the caller
+    /// has already identified the target slot by `ItemIndex` and needs a
+    /// removal that does not re-enter user code.
+    ///
+    /// The table holds at most one entry per `ItemIndex`, so this removes
+    /// at most one entry. Panics if no such entry exists — reaching this
+    /// state means the table and item set had already diverged before the
+    /// call, which is a hard invariant violation.
+    pub(crate) fn remove_by_index(&mut self, ix: ItemIndex) {
+        let mut found = false;
+        self.items.retain(|stored| {
+            if !found && stored.ix == ix {
+                found = true;
+                false
+            } else {
+                true
+            }
+        });
+        assert!(
+            found,
+            "linear scan should locate the index that find_entry_by_hash missed"
+        );
+    }
+
     /// Clears the hash table, removing all items.
     #[inline]
     pub(crate) fn clear(&mut self) {

--- a/crates/iddqd/src/tri_hash_map/imp.rs
+++ b/crates/iddqd/src/tri_hash_map/imp.rs
@@ -2712,36 +2712,45 @@ impl<T: TriHashItem, S: Clone + BuildHasher, A: Allocator> TriHashMap<T, S, A> {
         // might be pathological. hashbrown's `find_entry_by_hash` is
         // panic-safe because the table is not mutated until
         // `OccupiedEntry::remove` is called, so a panic while hashing leaves
-        // items and all three tables unmodified.
+        // items and all three tables unmodified. (Unlike the IdOrdMap path,
+        // no separate two-phase commit is needed: the BTreeMap analog has to
+        // guard against a user-`Ord` panic during the tree walk, but the
+        // hash walk here never invokes user code.)
+        //
+        // If any hash lookup misses — which happens when a `mem::forget` on
+        // a `RefMut` bypassed the drop-time hash check and one of the item's
+        // keys now hashes to a different bucket than its entry sits in —
+        // fall back to a linear scan by `ItemIndex` for that table. The
+        // fallback never invokes user `Hash`, so cleanup remains panic-safe.
         let item = self.items.get(remove_index)?;
         let state = &self.tables.state;
         let hash1 = state.hash_one(item.key1());
         let hash2 = state.hash_one(item.key2());
         let hash3 = state.hash_one(item.key3());
-        let Ok(entry1) = self
+        match self
             .tables
             .k1_to_item
             .find_entry_by_hash(hash1, |index| index == remove_index)
-        else {
-            panic!("remove_index {remove_index} not found in k1_to_item");
-        };
-        let Ok(entry2) = self
+        {
+            Ok(entry) => entry.remove(),
+            Err(()) => self.tables.k1_to_item.remove_by_index(remove_index),
+        }
+        match self
             .tables
             .k2_to_item
             .find_entry_by_hash(hash2, |index| index == remove_index)
-        else {
-            panic!("remove_index {remove_index} not found in k2_to_item");
-        };
-        let Ok(entry3) = self
+        {
+            Ok(entry) => entry.remove(),
+            Err(()) => self.tables.k2_to_item.remove_by_index(remove_index),
+        }
+        match self
             .tables
             .k3_to_item
             .find_entry_by_hash(hash3, |index| index == remove_index)
-        else {
-            panic!("remove_index {remove_index} not found in k3_to_item");
-        };
-        entry1.remove();
-        entry2.remove();
-        entry3.remove();
+        {
+            Ok(entry) => entry.remove(),
+            Err(()) => self.tables.k3_to_item.remove_by_index(remove_index),
+        }
         Some(
             self.items
                 .remove(remove_index)

--- a/crates/iddqd/tests/integration/pathological.rs
+++ b/crates/iddqd/tests/integration/pathological.rs
@@ -8,8 +8,8 @@ use crate::panic_safety::{PanickyKey, arm_panic_after, disarm_panic};
 use core::cell::Cell;
 use iddqd::{
     BiHashItem, BiHashMap, Comparable, Equivalent, IdHashItem, IdHashMap,
-    IdOrdItem, IdOrdMap, TriHashItem, TriHashMap, bi_upcast, id_ord_map,
-    id_upcast,
+    IdOrdItem, IdOrdMap, TriHashItem, TriHashMap, bi_upcast, id_hash_map,
+    id_ord_map, id_upcast,
     internal::{ValidateChaos, ValidateCompact},
     tri_upcast,
 };
@@ -745,6 +745,55 @@ fn id_ord_hash_blind_key_change_remove_reinsert_iter_mut_no_aliasing() {
     for item in &mut items {
         item.value += 1;
     }
+}
+
+// Test: hash-map analog of the IdOrdMap test above.
+
+#[derive(Debug)]
+struct ForgettableHashItem {
+    id: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ForgettableHashKey(u32);
+
+impl IdHashItem for ForgettableHashItem {
+    type Key<'a> = ForgettableHashKey;
+    fn key(&self) -> Self::Key<'_> {
+        ForgettableHashKey(self.id)
+    }
+    id_upcast!();
+}
+
+#[test]
+fn id_hash_silent_key_change_entry_remove_no_panic() {
+    let mut map = IdHashMap::<ForgettableHashItem>::new();
+    for id in 0..8u32 {
+        map.insert_unique(ForgettableHashItem { id }).unwrap();
+    }
+
+    let id_hash_map::Entry::Occupied(mut entry) =
+        map.entry(ForgettableHashKey(3))
+    else {
+        panic!("we just inserted id 3 in the loop above");
+    };
+    let mut ref_mut = entry.get_mut();
+    ref_mut.id = 10_000;
+    // This bypasses the drop-time hash equality check on the ID.
+    std::mem::forget(ref_mut);
+
+    // Now call `entry.remove()`. This will not succeed at efficient removal.
+    // But we have a linear-scan fallback in place, due to which cleanup
+    // succeeds.
+    let removed = entry.remove();
+    assert_eq!(removed.id, 10_000);
+
+    // The seven other items must still be findable.
+    for id in [0u32, 1, 2, 4, 5, 6, 7] {
+        assert!(map.contains_key(&ForgettableHashKey(id)));
+    }
+    map.validate(ValidateCompact::NonCompact)
+        .expect("map remains valid after silent-mutation remove");
 }
 
 #[test]


### PR DESCRIPTION
Similar to the recent `IdOrdMap` fix in #255. See the comments for more details.
