### PR TITLE
add compile-fail tests for and_modify and OccupiedEntry::for_each RefMut stashing

### DIFF
--- a/crates/iddqd/tests/ui/invalid/bi_hash_entry_and_modify_stash.rs
+++ b/crates/iddqd/tests/ui/invalid/bi_hash_entry_and_modify_stash.rs
@@ -1,0 +1,34 @@
+use iddqd::{BiHashItem, BiHashMap, bi_upcast};
+
+#[derive(Debug)]
+struct Item {
+    id: u32,
+    key2: u32,
+}
+
+impl BiHashItem for Item {
+    type K1<'a> = u32;
+    type K2<'a> = u32;
+
+    fn key1(&self) -> Self::K1<'_> {
+        self.id
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        self.key2
+    }
+
+    bi_upcast!();
+}
+
+fn main() {
+    let mut map = BiHashMap::<Item>::new();
+    map.insert_unique(Item { id: 0, key2: 10 }).unwrap();
+
+    let mut stashed = Vec::new();
+    map.entry(0, 10).and_modify(|item| {
+        stashed.push(item);
+    });
+
+    stashed[0].id = 1;
+}

--- a/crates/iddqd/tests/ui/invalid/bi_hash_entry_and_modify_stash.stderr
+++ b/crates/iddqd/tests/ui/invalid/bi_hash_entry_and_modify_stash.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/invalid/bi_hash_entry_and_modify_stash.rs:30:9
+   |
+28 |     let mut stashed = Vec::new();
+   |         ----------- `stashed` declared here, outside of the closure body
+29 |     map.entry(0, 10).and_modify(|item| {
+   |                                  ---- `item` is a reference that is only valid in the closure body
+30 |         stashed.push(item);
+   |         ^^^^^^^^^^^^^^^^^^ `item` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<iddqd::bi_hash_map::RefMut<'_, Item>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/crates/iddqd/tests/ui/invalid/bi_hash_occupied_entry_mut_for_each_stash.rs
+++ b/crates/iddqd/tests/ui/invalid/bi_hash_occupied_entry_mut_for_each_stash.rs
@@ -1,0 +1,42 @@
+use iddqd::{BiHashItem, bi_hash_map, bi_upcast};
+
+#[derive(Debug)]
+struct Item {
+    id: u32,
+    key2: u32,
+}
+
+impl BiHashItem for Item {
+    type K1<'a> = u32;
+    type K2<'a> = u32;
+
+    fn key1(&self) -> Self::K1<'_> {
+        self.id
+    }
+
+    fn key2(&self) -> Self::K2<'_> {
+        self.key2
+    }
+
+    bi_upcast!();
+}
+
+fn main() {
+    let mut map = bi_hash_map! {
+        Item { id: 0, key2: 10 },
+        Item { id: 1, key2: 11 },
+    };
+
+    let mut entry = match map.entry(0, 11) {
+        iddqd::bi_hash_map::Entry::Occupied(entry) => entry,
+        iddqd::bi_hash_map::Entry::Vacant(_) => unreachable!(),
+    };
+
+    let mut refs = entry.get_mut();
+    let mut stashed = Vec::new();
+    refs.for_each(|item| {
+        stashed.push(item);
+    });
+
+    stashed[0].id = 2;
+}

--- a/crates/iddqd/tests/ui/invalid/bi_hash_occupied_entry_mut_for_each_stash.stderr
+++ b/crates/iddqd/tests/ui/invalid/bi_hash_occupied_entry_mut_for_each_stash.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/invalid/bi_hash_occupied_entry_mut_for_each_stash.rs:38:9
+   |
+36 |     let mut stashed = Vec::new();
+   |         ----------- `stashed` declared here, outside of the closure body
+37 |     refs.for_each(|item| {
+   |                    ---- `item` is a reference that is only valid in the closure body
+38 |         stashed.push(item);
+   |         ^^^^^^^^^^^^^^^^^^ `item` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<iddqd::bi_hash_map::RefMut<'_, Item>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/crates/iddqd/tests/ui/invalid/id_hash_entry_and_modify_stash.rs
+++ b/crates/iddqd/tests/ui/invalid/id_hash_entry_and_modify_stash.rs
@@ -1,0 +1,28 @@
+use iddqd::{IdHashItem, IdHashMap, id_upcast};
+
+#[derive(Debug)]
+struct Item {
+    id: u32,
+}
+
+impl IdHashItem for Item {
+    type Key<'a> = u32;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.id
+    }
+
+    id_upcast!();
+}
+
+fn main() {
+    let mut map = IdHashMap::<Item>::new();
+    map.insert_unique(Item { id: 0 }).unwrap();
+
+    let mut stashed = Vec::new();
+    map.entry(0).and_modify(|item| {
+        stashed.push(item);
+    });
+
+    stashed[0].id = 1;
+}

--- a/crates/iddqd/tests/ui/invalid/id_hash_entry_and_modify_stash.stderr
+++ b/crates/iddqd/tests/ui/invalid/id_hash_entry_and_modify_stash.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/invalid/id_hash_entry_and_modify_stash.rs:24:9
+   |
+22 |     let mut stashed = Vec::new();
+   |         ----------- `stashed` declared here, outside of the closure body
+23 |     map.entry(0).and_modify(|item| {
+   |                              ---- `item` is a reference that is only valid in the closure body
+24 |         stashed.push(item);
+   |         ^^^^^^^^^^^^^^^^^^ `item` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<iddqd::id_hash_map::RefMut<'_, Item>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/crates/iddqd/tests/ui/invalid/id_ord_entry_and_modify_stash.rs
+++ b/crates/iddqd/tests/ui/invalid/id_ord_entry_and_modify_stash.rs
@@ -1,0 +1,28 @@
+use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
+
+#[derive(Debug)]
+struct Item {
+    id: u32,
+}
+
+impl IdOrdItem for Item {
+    type Key<'a> = u32;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.id
+    }
+
+    id_upcast!();
+}
+
+fn main() {
+    let mut map = IdOrdMap::<Item>::new();
+    map.insert_unique(Item { id: 0 }).unwrap();
+
+    let mut stashed = Vec::new();
+    map.entry(0).and_modify(|item| {
+        stashed.push(item);
+    });
+
+    stashed[0].id = 1;
+}

--- a/crates/iddqd/tests/ui/invalid/id_ord_entry_and_modify_stash.stderr
+++ b/crates/iddqd/tests/ui/invalid/id_ord_entry_and_modify_stash.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/invalid/id_ord_entry_and_modify_stash.rs:24:9
+   |
+22 |     let mut stashed = Vec::new();
+   |         ----------- `stashed` declared here, outside of the closure body
+23 |     map.entry(0).and_modify(|item| {
+   |                              ---- `item` is a reference that is only valid in the closure body
+24 |         stashed.push(item);
+   |         ^^^^^^^^^^^^^^^^^^ `item` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<iddqd::id_ord_map::RefMut<'_, Item>>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance


### PR DESCRIPTION
Ensure that the refs can't outlive the callback.
