### PR TITLE
[iddqd] split structural validation into validate_structural

### DIFF
--- a/crates/iddqd/src/bi_hash_map/imp.rs
+++ b/crates/iddqd/src/bi_hash_map/imp.rs
@@ -1102,10 +1102,12 @@ impl<T: BiHashItem, S: Clone + BuildHasher, A: Allocator> BiHashMap<T, S, A> {
     where
         T: fmt::Debug,
     {
-        self.items.validate(compactness)?;
-        self.tables.validate(self.len(), compactness)?;
+        self.validate_structural(compactness)?;
 
         // Check that the indexes are all correct.
+        //
+        // Unlike the structural checks, this re-looks up each key through the
+        // user `Hash`, so it only holds when that `Hash` is lawful.
         for (ix, item) in self.items.iter() {
             let key1 = item.key1();
             let key2 = item.key2();
@@ -1128,6 +1130,27 @@ impl<T: BiHashItem, S: Clone + BuildHasher, A: Allocator> BiHashMap<T, S, A> {
             }
         }
 
+        Ok(())
+    }
+
+    /// Checks the structural invariants of the map:
+    ///
+    /// * The item set is well-formed.
+    /// * Each per-key hash table holds exactly one entry per live item, with no
+    ///   duplicate `ItemIndex`es.
+    ///
+    /// Unlike [`validate`](Self::validate), this does not re-look-up keys
+    /// through the user `Hash`, so it holds regardless of whether that `Hash`
+    /// is lawful. A buggy hasher can desync the logical key→item mapping, but
+    /// it must never break these structural invariants! Doing so would be
+    /// unsoundness, e.g. duplicate indexes enabling mutable aliasing.
+    #[doc(hidden)]
+    pub fn validate_structural(
+        &self,
+        compactness: ValidateCompact,
+    ) -> Result<(), ValidationError> {
+        self.items.validate(compactness)?;
+        self.tables.validate(self.len(), compactness)?;
         Ok(())
     }
 

--- a/crates/iddqd/src/id_hash_map/imp.rs
+++ b/crates/iddqd/src/id_hash_map/imp.rs
@@ -897,10 +897,12 @@ impl<T: IdHashItem, S: Clone + BuildHasher, A: Allocator> IdHashMap<T, S, A> {
     where
         T: fmt::Debug,
     {
-        self.items.validate(compactness)?;
-        self.tables.validate(self.len(), compactness)?;
+        self.validate_structural(compactness)?;
 
         // Check that the indexes are all correct.
+        //
+        // Unlike the structural checks above, this re-looks up each key through
+        // the user `Hash`, so it only holds when that `Hash` is lawful.
         for (ix, item) in self.items.iter() {
             let key = item.key();
             let Some(ix1) = self.find_index(&key) else {
@@ -916,6 +918,27 @@ impl<T: IdHashItem, S: Clone + BuildHasher, A: Allocator> IdHashMap<T, S, A> {
             }
         }
 
+        Ok(())
+    }
+
+    /// Checks the structural invariants of the map:
+    ///
+    /// * The item set is well-formed.
+    /// * The hash table holds exactly one entry per live item, with no
+    ///   duplicate `ItemIndex`es.
+    ///
+    /// Unlike [`validate`](Self::validate), this does not re-look-up keys
+    /// through the user `Hash`, so it holds regardless of whether that `Hash`
+    /// is lawful. A buggy hasher can desync the logical key→item mapping, but
+    /// it must never break these structural invariants! Doing so would be
+    /// unsoundness, e.g. duplicate indexes enabling mutable aliasing.
+    #[doc(hidden)]
+    pub fn validate_structural(
+        &self,
+        compactness: ValidateCompact,
+    ) -> Result<(), ValidationError> {
+        self.items.validate(compactness)?;
+        self.tables.validate(self.len(), compactness)?;
         Ok(())
     }
 

--- a/crates/iddqd/src/tri_hash_map/imp.rs
+++ b/crates/iddqd/src/tri_hash_map/imp.rs
@@ -1265,10 +1265,12 @@ impl<T: TriHashItem, S: Clone + BuildHasher, A: Allocator> TriHashMap<T, S, A> {
     where
         T: fmt::Debug,
     {
-        self.items.validate(compactness)?;
-        self.tables.validate(self.len(), compactness)?;
+        self.validate_structural(compactness)?;
 
         // Check that the indexes are all correct.
+        //
+        // Unlike the structural checks, this re-looks up each key through the
+        // user `Hash`, so it only holds when that `Hash` is lawful.
         for (ix, item) in self.items.iter() {
             let key1 = item.key1();
             let key2 = item.key2();
@@ -1297,6 +1299,27 @@ impl<T: TriHashItem, S: Clone + BuildHasher, A: Allocator> TriHashMap<T, S, A> {
             }
         }
 
+        Ok(())
+    }
+
+    /// Checks the structural invariants of the map:
+    ///
+    /// * The item set is well-formed.
+    /// * Each per-key hash table holds exactly one entry per live item, with no
+    ///   duplicate `ItemIndex`es.
+    ///
+    /// Unlike [`validate`](Self::validate), this does not re-look-up keys
+    /// through the user `Hash`, so it holds regardless of whether that `Hash`
+    /// is lawful. A buggy hasher can desync the logical key→item mapping, but
+    /// it must never break these structural invariants! Doing so would be
+    /// unsoundness, e.g. duplicate indexes enabling mutable aliasing.
+    #[doc(hidden)]
+    pub fn validate_structural(
+        &self,
+        compactness: crate::internal::ValidateCompact,
+    ) -> Result<(), ValidationError> {
+        self.items.validate(compactness)?;
+        self.tables.validate(self.len(), compactness)?;
         Ok(())
     }
 

--- a/crates/iddqd/tests/integration/pathological.rs
+++ b/crates/iddqd/tests/integration/pathological.rs
@@ -510,6 +510,8 @@ fn id_hash_misdirected_eq_remove_reinsert_retain_no_aliasing() {
     let removed = map.remove(&ExactLookupKey { id: 1 }).unwrap();
     MISDIRECTED_EQ_MODE.with(|c| c.set(false));
     assert_eq!(removed.id, 1);
+    map.validate_structural(ValidateCompact::NonCompact)
+        .expect("structurally sound after misdirected remove");
 
     map.insert_unique(MisdirectedEqIdHashItem { id: 2 }).unwrap();
 
@@ -554,6 +556,8 @@ fn bi_hash_misdirected_eq_remove_reinsert_retain_no_aliasing() {
     let removed = map.remove1(&ExactLookupKey { id: 1 }).unwrap();
     MISDIRECTED_EQ_MODE.with(|c| c.set(false));
     assert_eq!(removed.id, 1);
+    map.validate_structural(ValidateCompact::NonCompact)
+        .expect("structurally sound after misdirected remove");
 
     map.insert_unique(MisdirectedEqBiHashItem { id: 2 }).unwrap();
 
@@ -602,6 +606,8 @@ fn tri_hash_misdirected_eq_remove_reinsert_retain_no_aliasing() {
     let removed = map.remove1(&ExactLookupKey { id: 1 }).unwrap();
     MISDIRECTED_EQ_MODE.with(|c| c.set(false));
     assert_eq!(removed.id, 1);
+    map.validate_structural(ValidateCompact::NonCompact)
+        .expect("structurally sound after misdirected remove");
 
     map.insert_unique(MisdirectedEqTriHashItem { id: 2 }).unwrap();
 
@@ -852,6 +858,8 @@ fn bi_hash_silent_secondary_key_change_retain_no_panic() {
     // This bypasses the drop-time hash equality check on key2, leaving the k2
     // table entry in the old hash bucket.
     std::mem::forget(ref_mut);
+    map.validate_structural(ValidateCompact::NonCompact)
+        .expect("structurally sound with a stranded key2 entry");
 
     map.retain(|_| false);
 
@@ -877,6 +885,8 @@ fn tri_hash_silent_secondary_key_change_retain_no_panic() {
     // This bypasses the drop-time hash equality check on key3, leaving the k3
     // table entry in the old hash bucket.
     std::mem::forget(ref_mut);
+    map.validate_structural(ValidateCompact::NonCompact)
+        .expect("structurally sound with a stranded key3 entry");
 
     map.retain(|_| false);
 


### PR DESCRIPTION
The `validate` method does two conceptually different things:

* It checks the map's structural invariants (the item set is well-formed; each hash table holds exactly one entry per live item; no duplicate ItemIndexes).
* Every key->item mapping through the user `Hash` is valid.

Observe that only the latter depends on the `Hash` impl being valid (lawful).

Pull the structural half out into `validate_structural` so callers can assert soundness even under an adversarial or buggy hasher, where the logical key->item mapping is allowed to desync but the structure must not.

Also exercise this in the pathological adversarial tests.
