### PR TITLE
[iddqd] add a Soteria proof harness and some simple ItemSet proofs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,25 @@
+[experimental]
+setup-scripts = true
+
 [profile.default-miri]
 # proptests are too slow to be run through miri
 default-filter = "not test(proptest) and not binary_id(iddqd::ui)"
+
+# Profile for running Soteria proofs.
+#
+# The proofs live in `crates/iddqd-soteria-runner/tests/runner.rs`, each
+# shelling out to one `soteria-rust` entrypoint. Soteria executes its tests
+# serially, so we use nextest's process-per-test scheduling to ensure that
+# execution is parallel.
+#
+# Run via `just soteria`.
+[profile.soteria]
+# Some proofs run for several minutes.
+slow-timeout = { period = "120s", terminate-after = 20 }
+
+[scripts.setup.soteria-compile]
+command = "scripts/soteria-compile"
+
+[[profile.soteria.scripts]]
+filter = "binary_id(iddqd-soteria-runner::runner)"
+setup = "soteria-compile"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,3 +168,32 @@ jobs:
         run: cargo +nightly miri nextest run -p iddqd
       - name: Doctests
         run: cargo +nightly miri test --doc -p iddqd
+
+  soteria:
+    name: Soteria proofs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: soteria
+      - uses: taiki-e/install-action@just
+      - uses: taiki-e/install-action@nextest
+      # Soteria publishes only a single rolling `nightly` bundle, and `cargo
+      # soteria setup` always installs whatever the tag points out. The cache
+      # below is mainly for speed -- it (unfortunately) doesn't provide any
+      # determinism.
+      - name: Cache Soteria toolchain
+        id: soteria-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.soteria
+          key: soteria-bundle-v1
+      - name: Install Soteria
+        if: steps.soteria-cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install soteria --git https://github.com/soteria-tools/cargo-soteria.git
+          cargo soteria setup
+      - name: Run proofs
+        run: just soteria

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
       - uses: taiki-e/install-action@just
       - uses: taiki-e/install-action@nextest
       # Soteria publishes only a single rolling `nightly` bundle, and `cargo
-      # soteria setup` always installs whatever the tag points out. The cache
+      # soteria setup` always installs whatever the tag points to. The cache
       # below is mainly for speed -- it (unfortunately) doesn't provide any
       # determinism.
       - name: Cache Soteria toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,5 +195,14 @@ jobs:
         run: |
           cargo install soteria --git https://github.com/soteria-tools/cargo-soteria.git
           cargo soteria setup
+      # The cache covers ~/.soteria but not the rustc toolchain Charon pins (a
+      # specific nightly under ~/.rustup), which `cargo soteria setup` installs
+      # via `obol toolchain-path`. On a cache hit that step is skipped, so
+      # provision it directly from the cached bundle's obol -- this picks up
+      # whatever nightly the bundle needs and no-ops if it's already installed.
+      - name: Provision Charon toolchain
+        run: |
+          obol="$(find ~/.soteria -mindepth 2 -maxdepth 2 -type d -name bin | sort -V | tail -1)/obol"
+          "$obol" toolchain-path
       - name: Run proofs
         run: just soteria

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /mutants.out*
+# Soteria symbolic-execution frontend output (see `just soteria`).
+*.llbc.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "iddqd-soteria-runner"
+version = "0.1.0"
+
+[[package]]
 name = "iddqd-test-utils"
 version = "0.1.0"
 dependencies = [

--- a/Justfile
+++ b/Justfile
@@ -21,6 +21,10 @@ rustdoc *args:
 generate-readmes:
     cargo sync-rdme --toolchain nightly-2026-04-30 --workspace --all-features
 
+# Run the Soteria symbolic-execution proofs in parallel (process-per-test).
+soteria *args:
+    cargo nextest run --profile soteria --run-ignored all -E 'binary_id(iddqd-soteria-runner::runner)' {{args}}
+
 # Run cargo release in CI.
 ci-cargo-release:
     # cargo-release requires a release off a branch.

--- a/Justfile
+++ b/Justfile
@@ -23,7 +23,7 @@ generate-readmes:
 
 # Run the Soteria symbolic-execution proofs in parallel (process-per-test).
 soteria *args:
-    cargo nextest run --profile soteria --run-ignored all -E 'binary_id(iddqd-soteria-runner::runner)' {{args}}
+    cargo nextest run -p iddqd-soteria-runner --profile soteria --run-ignored all -E 'binary_id(iddqd-soteria-runner::runner)' {{args}}
 
 # Run cargo release in CI.
 ci-cargo-release:

--- a/crates/iddqd-soteria-runner/Cargo.toml
+++ b/crates/iddqd-soteria-runner/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "iddqd-soteria-runner"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[lints]
+workspace = true

--- a/crates/iddqd-soteria-runner/README.md
+++ b/crates/iddqd-soteria-runner/README.md
@@ -1,0 +1,3 @@
+# iddqd-soteria-runner
+
+Parallel runner for the iddqd Soteria proofs.

--- a/crates/iddqd-soteria-runner/src/lib.rs
+++ b/crates/iddqd-soteria-runner/src/lib.rs
@@ -1,0 +1,1 @@
+//! Parallel runner for the iddqd Soteria proofs.

--- a/crates/iddqd-soteria-runner/tests/runner.rs
+++ b/crates/iddqd-soteria-runner/tests/runner.rs
@@ -46,5 +46,5 @@ macro_rules! lib_proof {
 }
 
 // Keep in sync with the `#[soteria::test]` entrypoints in iddqd/src/proofs.rs.
-lib_proof!(item_set_insert_assigns_dense_indices);
+lib_proof!(item_set_insert_assigns_dense_indexes);
 lib_proof!(item_set_remove_then_insert_reuses_freed_slot);

--- a/crates/iddqd-soteria-runner/tests/runner.rs
+++ b/crates/iddqd-soteria-runner/tests/runner.rs
@@ -1,0 +1,50 @@
+//! Runs each iddqd Soteria proof in its own process so `cargo nextest run` can
+//! schedule them across cores. Soteria executes entrypoints serially and largely
+//! single-threaded, so we use nextest to get parallelism.
+//!
+//! The ULLBC is compiled once by the nextest setup script; each test here
+//! reuses it with `--no-compile`.
+//!
+//! These tests shell out to the Soteria toolchain, so they are `#[ignore]`d by
+//! default and only run via `just soteria`.
+
+use std::{path::PathBuf, process::Command};
+
+fn workspace_root() -> PathBuf {
+    std::env::var_os("NEXTEST_WORKSPACE_ROOT").map(PathBuf::from).expect(
+        "NEXTEST_WORKSPACE_ROOT should be set by nextest; run the Soteria \
+         proofs via `just soteria`",
+    )
+}
+
+/// Shells out to one Soteria entrypoint, reusing the pre-compiled ULLBC.
+///
+/// `name` is matched as a trailing path segment (`::name$`), which is robust to
+/// the module nesting in `tests/soteria/`.
+fn run(mode_args: &[&str], name: &str) {
+    let root = workspace_root();
+    let status = Command::new(root.join("scripts/soteria-rust"))
+        .arg("exec")
+        .arg(root.join("crates/iddqd"))
+        .args(mode_args)
+        .args(["--no-compile", "--ignore-leaks", "--no-color", "--filter"])
+        .arg(format!("::{name}$"))
+        .status()
+        .expect("spawned scripts/soteria-rust");
+    assert!(status.success(), "Soteria proof `{name}` failed");
+}
+
+/// A proof defined in `crates/iddqd/src/proofs.rs`.
+macro_rules! lib_proof {
+    ($name:ident) => {
+        #[test]
+        #[ignore = "Soteria proof; run via `just soteria`"]
+        fn $name() {
+            run(&[], stringify!($name));
+        }
+    };
+}
+
+// Keep in sync with the `#[soteria::test]` entrypoints in iddqd/src/proofs.rs.
+lib_proof!(item_set_insert_assigns_dense_indices);
+lib_proof!(item_set_remove_then_insert_reuses_freed_slot);

--- a/crates/iddqd/src/lib.rs
+++ b/crates/iddqd/src/lib.rs
@@ -388,6 +388,8 @@ pub mod id_hash_map;
 pub mod id_ord_map;
 #[doc(hidden)]
 pub mod internal;
+#[cfg(soteria)]
+mod proofs;
 mod support;
 pub mod tri_hash_map;
 

--- a/crates/iddqd/src/proofs.rs
+++ b/crates/iddqd/src/proofs.rs
@@ -19,7 +19,7 @@ fn nondet_index_below(n: u32) -> u32 {
 }
 
 #[soteria::test]
-fn item_set_insert_assigns_dense_indices() {
+fn item_set_insert_assigns_dense_indexes() {
     let mut set: ItemSet<u32, Global> = ItemSet::new();
     let a = set.assert_can_grow().insert(10);
     let b = set.assert_can_grow().insert(20);

--- a/crates/iddqd/src/proofs.rs
+++ b/crates/iddqd/src/proofs.rs
@@ -1,0 +1,63 @@
+//! Symbolic-execution proof harnesses for iddqd internals that need
+//! `pub(crate)` access (currently the [`ItemSet`] slot container).
+//!
+//! This module is compiled only under the [Soteria] symbolic-execution
+//! frontend, which sets `--cfg soteria`.
+//!
+//! [Soteria]: https://soteria-tools.com
+
+use crate::{
+    internal::ValidateCompact,
+    support::{ItemIndex, alloc::Global, item_set::ItemSet},
+};
+
+/// Returns a symbolic `u32` constrained to `0 <= k < n`.
+fn nondet_index_below(n: u32) -> u32 {
+    let k: u32 = soteria::nondet_bytes();
+    soteria::assume(k < n);
+    k
+}
+
+#[soteria::test]
+fn item_set_insert_assigns_dense_indices() {
+    let mut set: ItemSet<u32, Global> = ItemSet::new();
+    let a = set.assert_can_grow().insert(10);
+    let b = set.assert_can_grow().insert(20);
+    let c = set.assert_can_grow().insert(30);
+    soteria::assert(a.as_u32() == 0, "first insert lands at index 0");
+    soteria::assert(b.as_u32() == 1, "second insert lands at index 1");
+    soteria::assert(c.as_u32() == 2, "third insert lands at index 2");
+    soteria::assert(set.len() == 3, "three inserts give len 3");
+    set.validate(ValidateCompact::Compact).expect("a hole-free set is compact");
+}
+
+/// The free-chain LIFO + structural-validity invariant: for any freed slot `k`,
+/// removing it then inserting reuses slot `k`, preserves `len`, and keeps the
+/// [`ItemSet`] invariant intact at every step.
+#[soteria::test]
+fn item_set_remove_then_insert_reuses_freed_slot() {
+    let mut set: ItemSet<u32, Global> = ItemSet::new();
+    set.assert_can_grow().insert(10);
+    set.assert_can_grow().insert(20);
+    set.assert_can_grow().insert(30);
+    set.validate(ValidateCompact::Compact).expect("fresh set is compact");
+
+    // Symbolic: which of the three occupied slots gets freed.
+    let k = nondet_index_below(3);
+    let removed = set.remove(ItemIndex::new(k));
+    soteria::assert(removed.is_some(), "removed an occupied slot");
+    soteria::assert(set.len() == 2, "remove decrements len");
+    set.validate(ValidateCompact::NonCompact)
+        .expect("one hole is a well-formed non-compact set");
+
+    // LIFO reuse: the next insert lands back in the just-freed slot k.
+    let reused = set.assert_can_grow().insert(99);
+    soteria::assert(reused == ItemIndex::new(k), "freed slot k is reused");
+    soteria::assert(set.len() == 3, "reinsert restores len");
+    soteria::assert(
+        set.get(ItemIndex::new(k)) == Some(&99),
+        "the reused slot holds the new value",
+    );
+    set.validate(ValidateCompact::Compact)
+        .expect("hole is filled, set is compact again");
+}

--- a/scripts/soteria-compile
+++ b/scripts/soteria-compile
@@ -29,4 +29,4 @@ echo "soteria-compile: building library ULLBC..."
 # Soteria doesn't appear to have a --no-run flag, so we pick a single
 # fast-running proof to match against.
 "$wrapper" exec crates/iddqd --no-color --ignore-leaks \
-    --filter '::item_set_insert_assigns_dense_indices$'
+    --filter '::item_set_insert_assigns_dense_indexes$'

--- a/scripts/soteria-compile
+++ b/scripts/soteria-compile
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# nextest setup script: compile the Soteria ULLBC once, up front, so the
+# per-proof runner tests can each reuse it with `--no-compile`.
+#
+# Produces the library artifact in crates/iddqd/:
+#   * crate.llbc.json -- the library entrypoints (src/proofs.rs)
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+cd "$here/.."
+wrapper="$here/soteria-rust"
+
+# Resolve the Soteria-only target dir once and hand it to the per-proof runs via
+# nextest's NEXTEST_ENV, so the compile and every proof share a target
+# directory. At runtime, each proof uses `--no-compile`, which reuses what we
+# build here.
+export SOTERIA_TARGET_DIR="${SOTERIA_TARGET_DIR:-$(pwd)/target/soteria}"
+if [[ -n "${NEXTEST_ENV:-}" ]]; then
+    echo "SOTERIA_TARGET_DIR=$SOTERIA_TARGET_DIR" >> "$NEXTEST_ENV"
+fi
+
+# Obol's incremental build state is not reliable across runs, so start each
+# compile from scratch. Removing this Soteria-only dir does not touch the normal
+# `cargo`/`nextest` target dir.
+rm -rf "$SOTERIA_TARGET_DIR"
+
+echo "soteria-compile: building library ULLBC..."
+"$wrapper" exec crates/iddqd --no-color --ignore-leaks \
+    --filter '::item_set_insert_assigns_dense_indices$'

--- a/scripts/soteria-compile
+++ b/scripts/soteria-compile
@@ -26,5 +26,7 @@ fi
 rm -rf "$SOTERIA_TARGET_DIR"
 
 echo "soteria-compile: building library ULLBC..."
+# Soteria doesn't appear to have a --no-run flag, so we pick a single
+# fast-running proof to match against.
 "$wrapper" exec crates/iddqd --no-color --ignore-leaks \
     --filter '::item_set_insert_assigns_dense_indices$'

--- a/scripts/soteria-rust
+++ b/scripts/soteria-rust
@@ -4,7 +4,7 @@
 # the right environment.
 set -euo pipefail
 
-bin="$(ls -d "${SOTERIA_HOME:-$HOME/.soteria}"/*/bin 2>/dev/null | sort -V | tail -1 || true)"
+bin="$(find "${SOTERIA_HOME:-$HOME/.soteria}" -mindepth 2 -maxdepth 2 -type d -name bin 2>/dev/null | sort -V | tail -1 || true)"
 if [[ -z "$bin" ]]; then
     echo "error: Soteria not found under ${SOTERIA_HOME:-$HOME/.soteria}. Install with:" >&2
     echo "  cargo install soteria --git https://github.com/soteria-tools/cargo-soteria.git" >&2
@@ -12,7 +12,9 @@ if [[ -z "$bin" ]]; then
     exit 1
 fi
 
-export SOTERIA_RUST_PLUGINS="$(dirname "$bin")/plugins"
+# Putting the definition and export on separate lines makes shellcheck SC2155 happy.
+SOTERIA_RUST_PLUGINS="$(dirname "$bin")/plugins"
+export SOTERIA_RUST_PLUGINS
 export SOTERIA_OBOL_PATH="$bin/obol"
 export SOTERIA_CHARON_PATH="$bin/charon"
 export SOTERIA_Z3_PATH="$bin/z3"
@@ -27,6 +29,6 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export CARGO_TARGET_DIR="${SOTERIA_TARGET_DIR:-$repo_root/target/soteria}"
 
 # Invoke the binary directly (as of 2026-06-11, the `cargo soteria`
-# cargo-subcommand wrapper leaks cargo's `soteria` token through as a stray
-# positional arg.
+# cargo-subcommand wrapper seems to pass cargo's `soteria` as a stray
+# positional arg, which seems like a bug in cargo-soteria?)
 exec soteria-rust "$@"

--- a/scripts/soteria-rust
+++ b/scripts/soteria-rust
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Wrapper that resolves the local Soteria install and runs `soteria-rust` with
+# the right environment.
+set -euo pipefail
+
+bin="$(ls -d "${SOTERIA_HOME:-$HOME/.soteria}"/*/bin 2>/dev/null | sort -V | tail -1 || true)"
+if [[ -z "$bin" ]]; then
+    echo "error: Soteria not found under ${SOTERIA_HOME:-$HOME/.soteria}. Install with:" >&2
+    echo "  cargo install soteria --git https://github.com/soteria-tools/cargo-soteria.git" >&2
+    echo "  cargo soteria setup" >&2
+    exit 1
+fi
+
+export SOTERIA_RUST_PLUGINS="$(dirname "$bin")/plugins"
+export SOTERIA_OBOL_PATH="$bin/obol"
+export SOTERIA_CHARON_PATH="$bin/charon"
+export SOTERIA_Z3_PATH="$bin/z3"
+export PATH="$bin:$PATH"
+
+# Build into a Soteria-only target dir.
+#
+# Under `just soteria`, SOTERIA_TARGET_DIR is resolved by
+# scripts/soteria-compile and propagated via nextest's NEXTEST_ENV. The fallback
+# below is for direct (non-nextest) runs.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export CARGO_TARGET_DIR="${SOTERIA_TARGET_DIR:-$repo_root/target/soteria}"
+
+# Invoke the binary directly (as of 2026-06-11, the `cargo soteria`
+# cargo-subcommand wrapper leaks cargo's `soteria` token through as a stray
+# positional arg.
+exec soteria-rust "$@"


### PR DESCRIPTION
Start adding the machinery to run Soterial symbolic-execution proofs:

* A dedicated `iddqd-soteria-runner` crate turns each proof into a separate test that shells out to one `soteria-rust` entrypoint.
* A nextest `soteria` profile compiles the ULLBC once up front and then schedules the proofs across cores.
* A new `just soteria` command drives the whole thing.

This requires Soteria to be installed, so normal test runs skip the proofs entirely.

Also add a couple of simple unit-level proofs for `ItemSet`.
