### PR TITLE
Point to insert_unique in code comment for IdOrdMap::from_iter_unique

### DIFF
--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -225,9 +225,9 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     ) -> Result<Self, DuplicateItem<T>> {
         let mut map = IdOrdMap::new();
         for value in iter {
-            // It would be nice to use insert_unique here, but that would
-            // return a `DuplicateItem<T, &T>`, which can only be converted into
-            // an owned value if T: Clone. Doing this via the Entry API means we
+            // It would be nice to use insert_unique here, but that would return
+            // a `DuplicateItem<T, &T>`, which can only be converted into an
+            // owned value if T: Clone. Doing this via the Entry API means we
             // can return a `DuplicateItem<T>` without requiring T to be Clone.
             match map.entry(value.key()) {
                 Entry::Occupied(entry) => {

--- a/crates/iddqd/src/id_ord_map/imp.rs
+++ b/crates/iddqd/src/id_ord_map/imp.rs
@@ -225,7 +225,7 @@ impl<T: IdOrdItem> IdOrdMap<T> {
     ) -> Result<Self, DuplicateItem<T>> {
         let mut map = IdOrdMap::new();
         for value in iter {
-            // It would be nice to use insert_overwrite here, but that would
+            // It would be nice to use insert_unique here, but that would
             // return a `DuplicateItem<T, &T>`, which can only be converted into
             // an owned value if T: Clone. Doing this via the Entry API means we
             // can return a `DuplicateItem<T>` without requiring T to be Clone.


### PR DESCRIPTION
👋 Hello! I was reading some code using `IdOrdMap` and then went on to read some of `IdOrdMap`'s implementation bits. 

As I was reading a comment in `from_iter_unique` (side-note: many thanks for leaving useful comments like that -- I was wondering about exactly the thing the comment talks about), I was a bit confused by it referring to `insert_overwrite` as the "would be nice if we could use this" idea. I _think_ it should be referring to `insert_unique` instead. So, I'm doing my open-source duty and offering a tiny PR to update this.

Apologies for the noise if I misunderstood things!